### PR TITLE
refactor: rename platform-api to cloud-api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
-module terraform-provider-platform-api
+module terraform-provider-cloud-api
 
 go 1.23.4
 
-require github.com/hashicorp/terraform-plugin-framework v1.3.3
+require (
+	github.com/hashicorp/terraform-plugin-framework v1.3.3
+	github.com/hashicorp/terraform-plugin-log v0.9.0
+)
 
 require (
 	github.com/fatih/color v1.13.0 // indirect
@@ -11,7 +14,6 @@ require (
 	github.com/hashicorp/go-plugin v1.6.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.18.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/internal/client/cloud_client.go
+++ b/internal/client/cloud_client.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// CloudClient is the HTTP client for the AuthZed Cloud API
+type CloudClient struct {
+	Host       string
+	Token      string
+	APIVersion string
+	HTTPClient *http.Client
+}
+
+// CloudClientConfig represents the config for the Cloud API client
+type CloudClientConfig struct {
+	Host       string
+	Token      string
+	APIVersion string
+	Timeout    time.Duration
+}
+
+// NewCloudClient creates a new Cloud API client
+func NewCloudClient(cfg *CloudClientConfig) *CloudClient {
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = DefaultTimeout
+	}
+
+	apiVersion := cfg.APIVersion
+	if apiVersion == "" {
+		apiVersion = DefaultAPIVersion
+	}
+
+	return &CloudClient{
+		Host:       cfg.Host,
+		Token:      cfg.Token,
+		APIVersion: apiVersion,
+		HTTPClient: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+// NewRequest creates a new HTTP request with the necessary headers
+func (c *CloudClient) NewRequest(method, path string, body interface{}) (*http.Request, error) {
+	// Fix URL construction to handle trailing slashes properly
+	host := c.Host
+	// Remove trailing slash from host if path starts with slash
+	if len(host) > 0 && host[len(host)-1] == '/' && len(path) > 0 && path[0] == '/' {
+		host = host[:len(host)-1]
+	}
+	url := fmt.Sprintf("%s%s", host, path)
+
+	var bodyReader io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(jsonBody)
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.Token))
+	req.Header.Set("X-API-Version", c.APIVersion)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	return req, nil
+}
+
+// Do sends an HTTP request and returns an HTTP response
+func (c *CloudClient) Do(req *http.Request) (*http.Response, error) {
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -9,8 +9,10 @@ import (
 
 type APIError struct {
 	StatusCode int
-	Message string
-	Body []byte
+	Message    string
+	URL        string
+	Method     string
+	Body       []byte
 }
 
 func (e *APIError) Error() string {
@@ -38,6 +40,8 @@ func NewAPIError(resp *http.Response) *APIError {
 	return &APIError{
 		StatusCode: resp.StatusCode,
 		Message:    errMsg,
+		URL:        resp.Request.URL.String(),
+		Method:     resp.Request.Method,
 		Body:       body,
 	}
 }

--- a/internal/client/permission_system.go
+++ b/internal/client/permission_system.go
@@ -10,9 +10,10 @@ import (
 	"terraform-provider-platform-api/internal/models"
 )
 
-// ListPermissionSystems retrieves all permiss
-func (c *PlatformClient) ListPermissionSystems() ([]models.PermissionSystem, error) {
-	req, err := c.NewRequest(http.MethodGet, "/ps", nil)
+// ListPermissionSystems retrieves all permission systems
+func (c *CloudClient) ListPermissionSystems() ([]models.PermissionSystem, error) {
+	path := "/ps"
+	req, err := c.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -56,9 +57,10 @@ func (c *PlatformClient) ListPermissionSystems() ([]models.PermissionSystem, err
 	return permissionSystems, nil
 }
 
-// GetPermissionSystem retrieves a ps by ID
-func (c *PlatformClient) GetPermissionSystem(id string) (*models.PermissionSystem, error) {
-	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("/ps/%s", id), nil)
+// GetPermissionSystem retrieves a permission system by ID
+func (c *CloudClient) GetPermissionSystem(permissionSystemID string) (*models.PermissionSystem, error) {
+	path := fmt.Sprintf("/ps/%s", permissionSystemID)
+	req, err := c.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +82,7 @@ func (c *PlatformClient) GetPermissionSystem(id string) (*models.PermissionSyste
 	}
 
 	// Log the raw response for debugging
-	fmt.Printf("DEBUG: Raw API response for permission system %s: %s\n", id, string(bodyBytes))
+	fmt.Printf("DEBUG: Raw API response for permission system %s: %s\n", permissionSystemID, string(bodyBytes))
 
 	// Create a new reader from the bytes for JSON decoding
 	bodyReader := bytes.NewReader(bodyBytes)

--- a/internal/client/policy.go
+++ b/internal/client/policy.go
@@ -8,8 +8,9 @@ import (
 )
 
 // ListPolicies retrieves all policies for a permission system
-func (c *PlatformClient) ListPolicies(permissionSystemID string) ([]models.Policy, error) {
-	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("/access/policies?permissionSystemID=%s", permissionSystemID), nil)
+func (c *CloudClient) ListPolicies(permissionSystemID string) ([]models.Policy, error) {
+	path := fmt.Sprintf("/ps/%s/access/policies", permissionSystemID)
+	req, err := c.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -34,9 +35,9 @@ func (c *PlatformClient) ListPolicies(permissionSystemID string) ([]models.Polic
 	return listResp.Items, nil
 }
 
-// GetPolicy retrieves a policy by its ID
-func (c *PlatformClient) GetPolicy(permissionSystemID, policyID string) (*models.Policy, error) {
-	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("/access/policies/%s?permissionSystemID=%s", policyID, permissionSystemID), nil)
+func (c *CloudClient) GetPolicy(permissionSystemID, policyID string) (*models.Policy, error) {
+	path := fmt.Sprintf("/ps/%s/access/policies/%s", permissionSystemID, policyID)
+	req, err := c.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +60,9 @@ func (c *PlatformClient) GetPolicy(permissionSystemID, policyID string) (*models
 	return &policy, nil
 }
 
-func (c *PlatformClient) CreatePolicy(policy *models.Policy) (*models.Policy, error) {
-	req, err := c.NewRequest(http.MethodPost, "/access/policies", policy)
+func (c *CloudClient) CreatePolicy(policy *models.Policy) (*models.Policy, error) {
+	path := fmt.Sprintf("/ps/%s/access/policies", policy.PermissionSystemID)
+	req, err := c.NewRequest(http.MethodPost, path, policy)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +85,9 @@ func (c *PlatformClient) CreatePolicy(policy *models.Policy) (*models.Policy, er
 	return &createdPolicy, nil
 }
 
-func (c *PlatformClient) DeletePolicy(permissionSystemID, policyID string) error {
-	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("/access/policies/%s?permissionSystemID=%s", policyID, permissionSystemID), nil)
+func (c *CloudClient) DeletePolicy(permissionSystemID, policyID string) error {
+	path := fmt.Sprintf("/ps/%s/access/policies/%s", permissionSystemID, policyID)
+	req, err := c.NewRequest(http.MethodDelete, path, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/client/service_account.go
+++ b/internal/client/service_account.go
@@ -8,8 +8,10 @@ import (
 	"terraform-provider-platform-api/internal/models"
 )
 
-func (c *PlatformClient) ListServiceAccounts(permissionSystemID string) ([]models.ServiceAccount, error) {
-	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("/access/service-accounts?permissionSystemID=%s", permissionSystemID), nil)
+func (c *CloudClient) ListServiceAccounts(permissionSystemID string) ([]models.ServiceAccount, error) {
+	path := fmt.Sprintf("/ps/%s/access/service-accounts", permissionSystemID)
+
+	req, err := c.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +48,10 @@ func (c *PlatformClient) ListServiceAccounts(permissionSystemID string) ([]model
 	return serviceAccounts, nil
 }
 
-func (c *PlatformClient) GetServiceAccount(permissionSystemID, serviceAccountID string) (*models.ServiceAccount, error) {
-	req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("/access/service-accounts/%s?permissionSystemID=%s", serviceAccountID, permissionSystemID), nil)
+func (c *CloudClient) GetServiceAccount(permissionSystemID, serviceAccountID string) (*models.ServiceAccount, error) {
+	path := fmt.Sprintf("/ps/%s/access/service-accounts/%s", permissionSystemID, serviceAccountID)
+
+	req, err := c.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -70,11 +74,30 @@ func (c *PlatformClient) GetServiceAccount(permissionSystemID, serviceAccountID 
 	return &serviceAccount, nil
 }
 
-func (c *PlatformClient) CreateServiceAccount(serviceAccount *models.ServiceAccount) (*models.ServiceAccount, error) {
-	req, err := c.NewRequest(http.MethodPost, "/access/service-accounts", serviceAccount)
+func (c *CloudClient) CreateServiceAccount(serviceAccount *models.ServiceAccount) (*models.ServiceAccount, error) {
+	path := fmt.Sprintf("/ps/%s/access/service-accounts", serviceAccount.PermissionSystemID)
+
+	// Debug logging
+	fmt.Printf("CreateServiceAccount called with:\n")
+	fmt.Printf("  - Host: %s\n", c.Host)
+	fmt.Printf("  - Path: %s\n", path)
+	fmt.Printf("  - Full URL will be: %s%s\n", c.Host, path)
+	fmt.Printf("  - PermissionSystemID: %s\n", serviceAccount.PermissionSystemID)
+	fmt.Printf("  - Name: %s\n", serviceAccount.Name)
+	fmt.Printf("  - Description: %s\n", serviceAccount.Description)
+
+	// Marshal service account to JSON for logging
+	jsonBytes, _ := json.Marshal(serviceAccount)
+	fmt.Printf("Request body: %s\n", string(jsonBytes))
+
+	req, err := c.NewRequest(http.MethodPost, path, serviceAccount)
 	if err != nil {
 		return nil, err
 	}
+
+	// Log the fully constructed URL
+	fmt.Printf("Final request URL: %s\n", req.URL.String())
+	fmt.Printf("Request headers: %+v\n", req.Header)
 
 	resp, err := c.Do(req)
 	if err != nil {
@@ -94,8 +117,10 @@ func (c *PlatformClient) CreateServiceAccount(serviceAccount *models.ServiceAcco
 	return &createdServiceAccount, nil
 }
 
-func (c *PlatformClient) DeleteServiceAccount(permissionSystemID, serviceAccountID string) error {
-	req, err := c.NewRequest(http.MethodDelete, fmt.Sprintf("/access/service-accounts/%s?permissionSystemID=%s", serviceAccountID, permissionSystemID), nil)
+func (c *CloudClient) DeleteServiceAccount(permissionSystemID, serviceAccountID string) error {
+	path := fmt.Sprintf("/ps/%s/access/service-accounts/%s", permissionSystemID, serviceAccountID)
+
+	req, err := c.NewRequest(http.MethodDelete, path, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/permission_system_data_source.go
+++ b/internal/provider/permission_system_data_source.go
@@ -19,7 +19,7 @@ func NewPermissionSystemDataSource() datasource.DataSource {
 }
 
 type permissionSystemDataSource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 type permissionSystemDataSourceModel struct {
@@ -119,11 +119,11 @@ func (d *permissionSystemDataSource) Configure(_ context.Context, req datasource
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/permission_systems_data_source.go
+++ b/internal/provider/permission_systems_data_source.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// Ensure the implementation satisfies the expected interfaces
 var _ datasource.DataSource = &permissionSystemsDataSource{}
 
 func NewPermissionSystemsDataSource() datasource.DataSource {
@@ -19,7 +18,7 @@ func NewPermissionSystemsDataSource() datasource.DataSource {
 }
 
 type permissionSystemsDataSource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 // permissionSystemsDataSourceModel maps the data source schema to values
@@ -28,7 +27,6 @@ type permissionSystemsDataSourceModel struct {
 	PermissionSystems []permissionSystemModelForList `tfsdk:"permission_systems"`
 }
 
-// permissionSystemModelForList is a simplified model for listing permission systems
 type permissionSystemModelForList struct {
 	ID            types.String `tfsdk:"id"`
 	Name          types.String `tfsdk:"name"`
@@ -81,11 +79,11 @@ func (d *permissionSystemsDataSource) Configure(_ context.Context, req datasourc
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/policies_data_source.go
+++ b/internal/provider/policies_data_source.go
@@ -18,7 +18,7 @@ func NewPoliciesDataSource() datasource.DataSource {
 }
 
 type policiesDataSource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 type policiesDataSourceModel struct {
@@ -104,11 +104,11 @@ func (d *policiesDataSource) Configure(_ context.Context, req datasource.Configu
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/policy_data_source.go
+++ b/internal/provider/policy_data_source.go
@@ -18,7 +18,7 @@ func NewPolicyDataSource() datasource.DataSource {
 }
 
 type policyDataSource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 type policyDataSourceModel struct {
@@ -87,11 +87,11 @@ func (d *policyDataSource) Configure(_ context.Context, req datasource.Configure
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -19,7 +19,7 @@ func NewPolicyResource() resource.Resource {
 }
 
 type policyResource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 type policyResourceModel struct {
@@ -83,11 +83,11 @@ func (r *policyResource) Configure(_ context.Context, req resource.ConfigureRequ
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,37 +12,37 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-type PlatformProvider struct {
+type CloudProvider struct {
 	version string
 }
 
-type PlatformProviderModel struct {
+type CloudProviderModel struct {
 	Endpoint   types.String `tfsdk:"endpoint"`
 	Token      types.String `tfsdk:"token"`
 	APIVersion types.String `tfsdk:"api_version"`
 }
 
-var _ provider.Provider = &PlatformProvider{}
+var _ provider.Provider = &CloudProvider{}
 
 func New(version string) func() provider.Provider {
 	return func() provider.Provider {
-		return &PlatformProvider{
+		return &CloudProvider{
 			version: version,
 		}
 	}
 }
 
-func (p *PlatformProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
-	resp.TypeName = "platform-api"
+func (p *CloudProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "cloud-api"
 	resp.Version = p.version
 }
 
-func (p *PlatformProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+func (p *CloudProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"endpoint": schema.StringAttribute{
 				Required:    true,
-				Description: "The host address of Platform API",
+				Description: "The host address of AuthZed Cloud API",
 			},
 			"token": schema.StringAttribute{
 				Required:    true,
@@ -57,26 +57,26 @@ func (p *PlatformProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 	}
 }
 
-func (p *PlatformProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	var config PlatformProviderModel
+func (p *CloudProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	var config CloudProviderModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	clientConfig := &client.PlatformClientConfig{
+	clientConfig := &client.CloudClientConfig{
 		Host:       config.Endpoint.ValueString(),
 		Token:      config.Token.ValueString(),
 		APIVersion: config.APIVersion.ValueString(),
 	}
 
-	platformClient := client.NewPlatformClient(clientConfig)
+	cloudClient := client.NewCloudClient(clientConfig)
 
-	resp.DataSourceData = platformClient
-	resp.ResourceData = platformClient
+	resp.DataSourceData = cloudClient
+	resp.ResourceData = cloudClient
 }
 
-func (p *PlatformProvider) Resources(_ context.Context) []func() resource.Resource {
+func (p *CloudProvider) Resources(_ context.Context) []func() resource.Resource {
 	resources := []func() resource.Resource{
 		NewRoleResource,
 		NewPolicyResource,
@@ -86,7 +86,7 @@ func (p *PlatformProvider) Resources(_ context.Context) []func() resource.Resour
 	return resources
 }
 
-func (p *PlatformProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+func (p *CloudProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	dataSources := []func() datasource.DataSource{
 		NewPermissionSystemDataSource,
 		NewPermissionSystemsDataSource,

--- a/internal/provider/role_data_source.go
+++ b/internal/provider/role_data_source.go
@@ -18,7 +18,7 @@ func NewRoleDataSource() datasource.DataSource {
 }
 
 type roleDataSource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 type roleDataSourceModel struct {
@@ -82,11 +82,11 @@ func (d *roleDataSource) Configure(_ context.Context, req datasource.ConfigureRe
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -19,7 +19,7 @@ func NewRoleResource() resource.Resource {
 }
 
 type roleResource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 type roleResourceModel struct {
@@ -78,11 +78,11 @@ func (r *roleResource) Configure(_ context.Context, req resource.ConfigureReques
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/roles_data_source.go
+++ b/internal/provider/roles_data_source.go
@@ -19,7 +19,7 @@ func NewRolesDataSource() datasource.DataSource {
 }
 
 type rolesDataSource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 type rolesDataSourceModel struct {
@@ -90,11 +90,11 @@ func (d *rolesDataSource) Configure(_ context.Context, req datasource.ConfigureR
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/service_account_data_source.go
+++ b/internal/provider/service_account_data_source.go
@@ -18,7 +18,7 @@ func NewServiceAccountDataSource() datasource.DataSource {
 }
 
 type serviceAccountDataSource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 type serviceAccountDataSourceModel struct {
@@ -76,11 +76,11 @@ func (d *serviceAccountDataSource) Configure(_ context.Context, req datasource.C
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/service_accounts_data_source.go
+++ b/internal/provider/service_accounts_data_source.go
@@ -18,7 +18,7 @@ func NewServiceAccountsDataSource() datasource.DataSource {
 }
 
 type serviceAccountsDataSource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 // serviceAccountsDataSourceModel maps the data source schema to values
@@ -89,11 +89,11 @@ func (d *serviceAccountsDataSource) Configure(_ context.Context, req datasource.
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/token_data_source.go
+++ b/internal/provider/token_data_source.go
@@ -17,7 +17,7 @@ func NewTokenDataSource() datasource.DataSource {
 }
 
 type TokenDataSource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 type TokenDataSourceModel struct {
@@ -75,17 +75,16 @@ func (d *TokenDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 	}
 }
 
-// Configure sets up the data source with the provider client
 func (d *TokenDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -21,7 +21,7 @@ func NewTokenResource() resource.Resource {
 }
 
 type TokenResource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
 type TokenResourceModel struct {
@@ -88,11 +88,11 @@ func (r *TokenResource) Configure(_ context.Context, req resource.ConfigureReque
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}

--- a/internal/provider/tokens_data_source.go
+++ b/internal/provider/tokens_data_source.go
@@ -10,20 +10,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// Ensure TokensDataSource satisfies the datasource interfaces
 var _ datasource.DataSource = &TokensDataSource{}
 
-// NewTokensDataSource returns a new tokens data source instance
 func NewTokensDataSource() datasource.DataSource {
 	return &TokensDataSource{}
 }
 
-// TokensDataSource defines the tokens data source implementation
 type TokensDataSource struct {
-	client *client.PlatformClient
+	client *client.CloudClient
 }
 
-// TokensDataSourceModel represents the tokens data source schema model
 type TokensDataSourceModel struct {
 	ID                 types.String    `tfsdk:"id"`
 	PermissionSystemID types.String    `tfsdk:"permission_system_id"`
@@ -32,7 +28,6 @@ type TokensDataSourceModel struct {
 	TokensCount        types.Int64     `tfsdk:"tokens_count"`
 }
 
-// TokenDataItem represents a single token in the list of tokens
 type TokenDataItem struct {
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
@@ -41,12 +36,10 @@ type TokenDataItem struct {
 	Creator     types.String `tfsdk:"creator"`
 }
 
-// Metadata returns the data source type name
 func (d *TokensDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_tokens"
 }
 
-// Schema defines the schema for the data source
 func (d *TokensDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Lists all tokens for a service account.",
@@ -99,17 +92,16 @@ func (d *TokensDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 	}
 }
 
-// Configure sets up the data source with the provider client
 func (d *TokensDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	client, ok := req.ProviderData.(*client.PlatformClient)
+	client, ok := req.ProviderData.(*client.CloudClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *client.PlatformClient, got: %T", req.ProviderData),
+			fmt.Sprintf("Expected *client.CloudClient, got: %T", req.ProviderData),
 		)
 		return
 	}
@@ -117,7 +109,6 @@ func (d *TokensDataSource) Configure(_ context.Context, req datasource.Configure
 	d.client = client
 }
 
-// Read fetches the tokens list from the API
 func (d *TokensDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var config TokensDataSourceModel
 	diags := req.Config.Get(ctx, &config)

--- a/main.go
+++ b/main.go
@@ -3,10 +3,8 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 	"os"
-	"runtime/debug"
 
 	"terraform-provider-platform-api/internal/provider"
 
@@ -18,42 +16,20 @@ var (
 )
 
 func init() {
-	// Redirect logs to stderr to avoid breaking the Terraform plugin protocol
 	log.SetOutput(os.Stderr)
 }
 
 func main() {
-	// Set up panic handler to log to stderr
-	defer func() {
-		if r := recover(); r != nil {
-			fmt.Fprintf(os.Stderr, "Panic: %v\n", r)
-			fmt.Fprintf(os.Stderr, "Stack: %s\n", debug.Stack())
-			os.Exit(1)
-		}
-	}()
-
-	// Set debug to false by default for normal Terraform operation
-	var debug = false
-
-	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers")
+	var debug bool
+	flag.BoolVar(&debug, "debug", false, "run provider with debugger support")
 	flag.Parse()
 
-	// Log important details (to stderr only when in debug mode)
-	if debug {
-		log.Println("Starting provider with debug =", debug)
-	}
-
-	ctx := context.Background()
-
 	opts := providerserver.ServeOpts{
-		Address: "registry.terraform.io/authzed/platform-api",
+		Address: "registry.terraform.io/authzed/cloud-api",
 		Debug:   debug,
 	}
 
-	err := providerserver.Serve(ctx, provider.New(version), opts)
-	if err != nil {
-		// Make sure error messages go to stderr as well
-		fmt.Fprintf(os.Stderr, "Error serving provider: %v\n", err)
+	if err := providerserver.Serve(context.Background(), provider.New(version), opts); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/openapi-spec.yaml
+++ b/openapi-spec.yaml
@@ -1,50 +1,1353 @@
 openapi: 3.0.3
 info:
-  description: this is a test API ![](https://commonmark.org/help/images/favicon.png)
-  title: some test API
-  version: ""
+  contact:
+    email: support@authzed.com
+  description: Platform API for AuthZed Dedicated
+  termsOfService: https://authzed.com/terms-conditions
+  title: AuthZed Platform API
+  version: 25r1
+externalDocs:
+  description: Find out more at the official Authzed Docs site
+  url: https://authzed.com/docs
+tags:
+- description: A permission system defines a managed SpiceDB instance
+  externalDocs:
+    description: Find out more at the official Authzed Docs site
+    url: https://authzed.com/docs
+  name: permission system
+- description: Set of APIs to for the fine-grained access management of a Permission
+    System
+  externalDocs:
+    description: Find out more at the official Authzed Docs site
+    url: https://authzed.com/docs/authzed/concepts/restricted-api-access
+  name: access management
 paths:
-  /hello:
+  /access/policies:
+    get:
+      description: list all permission system access-management polices
+      operationId: ListPolicies
+      parameters:
+      - in: query
+        name: permissionSystemID
+        required: true
+        schema:
+          pattern: ^ps-[a-zA-Z0-9-]+$
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListPoliciesResponse'
+          description: OK
+      security:
+      - auth: []
+      tags:
+      - access management
     post:
-      description: Say hello.
-      operationId: SayHello
+      description: create a permission system access-management policy
+      operationId: CreatePolicy
       parameters:
       - description: The version of the API to use. Must be specified.
         in: header
         name: X-API-Version
         schema:
-          default: "20241017"
+          default: 25r1
           description: The version of the API to use. Must be specified.
           type: string
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/V20241017SayHelloRequest'
+              $ref: '#/components/schemas/CreatePolicyRequest'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatePolicyResponse'
+          description: Created
+      security:
+      - auth: []
+      tags:
+      - access management
+  /access/policies/{policyID}:
+    delete:
+      description: delete a permission system access-management policy by its ID
+      operationId: DeletePolicy
+      parameters:
+      - in: query
+        name: permissionSystemID
+        required: true
+        schema:
+          pattern: ^ps-[a-zA-Z0-9-]+$
+          type: string
+      - in: path
+        name: policyID
+        required: true
+        schema:
+          pattern: ^apc-[a-zA-Z0-9-]+$
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "204":
+          description: No Content
+      security:
+      - auth: []
+      tags:
+      - access management
+    get:
+      description: get a permission system access-management policy by its ID
+      operationId: GetPolicy
+      parameters:
+      - in: query
+        name: permissionSystemID
+        required: true
+        schema:
+          pattern: ^ps-[a-zA-Z0-9-]+$
+          type: string
+      - in: path
+        name: policyID
+        required: true
+        schema:
+          pattern: ^apc-[a-zA-Z0-9-]+$
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/V20241017SayHelloResponse'
+                $ref: '#/components/schemas/GetPolicyResponse'
           description: OK
       security:
       - auth: []
+      tags:
+      - access management
+  /access/roles:
+    get:
+      description: list all permission system access-management roles
+      operationId: ListRoles
+      parameters:
+      - in: query
+        name: permissionSystemID
+        required: true
+        schema:
+          pattern: ^ps-[a-zA-Z0-9-]+$
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListRolesResponse'
+          description: OK
+      security:
+      - auth: []
+      tags:
+      - access management
+    post:
+      description: create a permission system access-management role
+      operationId: CreateRole
+      parameters:
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRoleRequest'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateRoleResponse'
+          description: Created
+      security:
+      - auth: []
+      tags:
+      - access management
+  /access/roles/{roleID}:
+    get:
+      description: get a permission system access-management role by its ID
+      operationId: GetRole
+      parameters:
+      - in: query
+        name: permissionSystemID
+        required: true
+        schema:
+          pattern: ^ps-[a-zA-Z0-9-]+$
+          type: string
+      - in: path
+        name: roleID
+        required: true
+        schema:
+          pattern: ^arl-[a-zA-Z0-9-]+$
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetRoleResponse'
+          description: OK
+      security:
+      - auth: []
+      tags:
+      - access management
+  /access/service-accounts:
+    get:
+      description: list all permission system access-management service accounts
+      operationId: ListServiceAccounts
+      parameters:
+      - in: query
+        name: permissionSystemID
+        required: true
+        schema:
+          pattern: ^ps-[a-zA-Z0-9-]+$
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListServiceAccountsResponse'
+          description: OK
+      security:
+      - auth: []
+      tags:
+      - access management
+    post:
+      description: create a permission system access-management service account
+      operationId: CreateServiceAccount
+      parameters:
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateServiceAccountRequest'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateServiceAccountResponse'
+          description: Created
+      security:
+      - auth: []
+      tags:
+      - access management
+  /access/service-accounts/{serviceAccountID}:
+    delete:
+      description: delete a permission system access-management service account by
+        its ID
+      operationId: DeleteServiceAccount
+      parameters:
+      - in: query
+        name: permissionSystemID
+        required: true
+        schema:
+          pattern: ^ps-[a-zA-Z0-9-]+$
+          type: string
+      - in: path
+        name: serviceAccountID
+        required: true
+        schema:
+          pattern: ^asa-[a-zA-Z0-9-]+$
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "204":
+          description: No Content
+      security:
+      - auth: []
+      tags:
+      - access management
+    get:
+      description: get a permission system access-management service account by its
+        ID
+      operationId: GetServiceAccount
+      parameters:
+      - in: query
+        name: permissionSystemID
+        required: true
+        schema:
+          pattern: ^ps-[a-zA-Z0-9-]+$
+          type: string
+      - in: path
+        name: serviceAccountID
+        required: true
+        schema:
+          pattern: ^asa-[a-zA-Z0-9-]+$
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetServiceAccountResponse'
+          description: OK
+      security:
+      - auth: []
+      tags:
+      - access management
+  /access/service-accounts/{serviceAccountID}/tokens:
+    get:
+      description: list all permission system access-management tokens under a service
+        account
+      operationId: ListTokens
+      parameters:
+      - in: query
+        name: permissionSystemID
+        required: true
+        schema:
+          pattern: ^ps-[a-zA-Z0-9-]+$
+          type: string
+      - in: path
+        name: serviceAccountID
+        required: true
+        schema:
+          pattern: ^asa-[a-zA-Z0-9-]+$
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListTokensResponse'
+          description: OK
+      security:
+      - auth: []
+      tags:
+      - access management
+    post:
+      description: create a permission system access-management token under a service
+        account
+      operationId: CreateToken
+      parameters:
+      - description: The globally unique ID for the containing Service Account
+        in: path
+        name: serviceAccountID
+        required: true
+        schema:
+          description: The globally unique ID for the containing Service Account
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTokenRequest'
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateTokenResponse'
+          description: Created
+      security:
+      - auth: []
+      tags:
+      - access management
+  /access/service-accounts/{serviceAccountID}/tokens/{tokenID}:
+    get:
+      description: get a permission system access-management token by its ID, under
+        a service account
+      operationId: GetToken
+      parameters:
+      - in: query
+        name: permissionSystemID
+        required: true
+        schema:
+          pattern: ^ps-[a-zA-Z0-9-]+$
+          type: string
+      - in: path
+        name: tokenID
+        required: true
+        schema:
+          pattern: ^atk-[a-zA-Z0-9-]+$
+          type: string
+      - in: path
+        name: serviceAccountID
+        required: true
+        schema:
+          pattern: ^asa-[a-zA-Z0-9-]+$
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTokenResponse'
+          description: OK
+      security:
+      - auth: []
+      tags:
+      - access management
+  /ps:
+    get:
+      description: list all permission systems
+      operationId: ListPermissionSystems
+      parameters:
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListPermissionSystemsResponse'
+          description: OK
+      security:
+      - auth: []
+      tags:
+      - permission system
+  /ps/{permissionSystemID}:
+    get:
+      description: get a permission system by its ID
+      operationId: GetPermissionSystem
+      parameters:
+      - in: path
+        name: permissionSystemID
+        required: true
+        schema:
+          type: string
+      - description: The version of the API to use. Must be specified.
+        in: header
+        name: X-API-Version
+        schema:
+          default: 25r1
+          description: The version of the API to use. Must be specified.
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPermissionSystemResponse'
+          description: OK
+      security:
+      - auth: []
+      tags:
+      - permission system
 components:
   schemas:
-    V20241017SayHelloRequest:
+    CreatePolicyRequest:
       properties:
+        createdAt:
+          description: The timestamp when the Policy was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Policy. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Policy. May be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Policy
+          readOnly: true
+          type: string
         name:
+          description: The name of the Policy
+          maxLength: 50
+          minLength: 1
           type: string
-        owner:
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
           type: string
+        principalID:
+          description: The ID of the Principal that this Policy is associated with
+          type: string
+        roleIDs:
+          description: The IDs of the Roles that this Policy is associated with. Currently
+            only allowed to be a single ID
+          items:
+            type: string
+          maxLength: 1
+          minLength: 1
+          type: array
+      required:
+      - permissionSystemID
+      - name
+      - principalID
+      - roleIDs
       type: object
-    V20241017SayHelloResponse:
+    CreatePolicyResponse:
+      properties:
+        createdAt:
+          description: The timestamp when the Policy was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Policy. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Policy. May be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Policy
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Policy
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        principalID:
+          description: The ID of the Principal that this Policy is associated with
+          type: string
+        roleIDs:
+          description: The IDs of the Roles that this Policy is associated with. Currently
+            only allowed to be a single ID
+          items:
+            type: string
+          maxLength: 1
+          minLength: 1
+          type: array
+      required:
+      - permissionSystemID
+      - name
+      - principalID
+      - roleIDs
+      type: object
+    CreateRoleRequest:
+      properties:
+        createdAt:
+          description: The timestamp when the Role was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Role. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Role. May be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Role
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Role
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        permissions:
+          $ref: '#/components/schemas/PermissionExprMap'
+      required:
+      - permissionSystemID
+      - name
+      - permissions
+      type: object
+    CreateRoleResponse:
+      properties:
+        createdAt:
+          description: The timestamp when the Role was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Role. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Role. May be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Role
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Role
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        permissions:
+          $ref: '#/components/schemas/PermissionExprMap'
+      required:
+      - permissionSystemID
+      - name
+      - permissions
+      type: object
+    CreateServiceAccountRequest:
+      properties:
+        createdAt:
+          description: The timestamp when the Service Account was created (RFC 3339).
+            May not be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Service Account. May
+            be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Service Account. May
+            be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Service Account
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Service Account
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        token:
+          description: The Tokens associated with this Service Account
+          items:
+            $ref: '#/components/schemas/Token'
+          readOnly: true
+          type: array
+      required:
+      - permissionSystemID
+      - name
+      type: object
+    CreateServiceAccountResponse:
+      properties:
+        createdAt:
+          description: The timestamp when the Service Account was created (RFC 3339).
+            May not be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Service Account. May
+            be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Service Account. May
+            be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Service Account
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Service Account
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        token:
+          description: The Tokens associated with this Service Account
+          items:
+            $ref: '#/components/schemas/Token'
+          readOnly: true
+          type: array
+      required:
+      - permissionSystemID
+      - name
+      type: object
+    CreateTokenRequest:
+      properties:
+        createdAt:
+          description: The timestamp when the Token was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Token. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Token. May be empty.
+          maxLength: 200
+          type: string
+        hash:
+          description: The SHA256 hash of the secret part of the token, without the
+            prefix
+          readOnly: true
+          type: string
+        id:
+          description: The globally unique ID for this Token
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Token
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        serviceAccountID:
+          description: The globally unique ID for the containing Service Account
+          type: string
+      required:
+      - permissionSystemID
+      - serviceAccountID
+      - name
+      type: object
+    CreateTokenResponse:
+      properties:
+        createdAt:
+          description: The timestamp when the Token was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Token. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Token. May be empty.
+          maxLength: 200
+          type: string
+        hash:
+          description: The SHA256 hash of the secret part of the token, without the
+            prefix
+          readOnly: true
+          type: string
+        id:
+          description: The globally unique ID for this Token
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Token
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        secret:
+          description: The secret for the token. Will not be returned again.
+          readOnly: true
+          type: string
+        serviceAccountID:
+          description: The globally unique ID for the containing Service Account
+          type: string
+      required:
+      - permissionSystemID
+      - serviceAccountID
+      - name
+      type: object
+    GetPermissionSystemResponse:
+      properties:
+        globalDnsPath:
+          description: The global DNS path for the Permission System
+          type: string
+        id:
+          description: The globally unique ID for this Permission System
+          type: string
+        name:
+          description: The name of the Permission System
+          type: string
+        systemState:
+          $ref: '#/components/schemas/PermissionsSystemState'
+        systemType:
+          description: The type of the Permission System, either 'development' or
+            'production'
+          type: string
+        version:
+          $ref: '#/components/schemas/SystemVersion'
+      type: object
+    GetPolicyResponse:
+      properties:
+        createdAt:
+          description: The timestamp when the Policy was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Policy. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Policy. May be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Policy
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Policy
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        principalID:
+          description: The ID of the Principal that this Policy is associated with
+          type: string
+        roleIDs:
+          description: The IDs of the Roles that this Policy is associated with. Currently
+            only allowed to be a single ID
+          items:
+            type: string
+          maxLength: 1
+          minLength: 1
+          type: array
+      required:
+      - permissionSystemID
+      - name
+      - principalID
+      - roleIDs
+      type: object
+    GetRoleResponse:
+      properties:
+        createdAt:
+          description: The timestamp when the Role was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Role. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Role. May be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Role
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Role
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        permissions:
+          $ref: '#/components/schemas/PermissionExprMap'
+      required:
+      - permissionSystemID
+      - name
+      - permissions
+      type: object
+    GetServiceAccountResponse:
+      properties:
+        createdAt:
+          description: The timestamp when the Service Account was created (RFC 3339).
+            May not be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Service Account. May
+            be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Service Account. May
+            be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Service Account
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Service Account
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        token:
+          description: The Tokens associated with this Service Account
+          items:
+            $ref: '#/components/schemas/Token'
+          readOnly: true
+          type: array
+      required:
+      - permissionSystemID
+      - name
+      type: object
+    GetTokenResponse:
+      properties:
+        createdAt:
+          description: The timestamp when the Token was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Token. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Token. May be empty.
+          maxLength: 200
+          type: string
+        hash:
+          description: The SHA256 hash of the secret part of the token, without the
+            prefix
+          readOnly: true
+          type: string
+        id:
+          description: The globally unique ID for this Token
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Token
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        serviceAccountID:
+          description: The globally unique ID for the containing Service Account
+          type: string
+      required:
+      - permissionSystemID
+      - serviceAccountID
+      - name
+      type: object
+    ListPermissionSystemsResponse:
+      items:
+        $ref: '#/components/schemas/PermissionSystem'
+      nullable: true
+      type: array
+    ListPoliciesResponse:
+      items:
+        $ref: '#/components/schemas/Policy'
+      nullable: true
+      type: array
+    ListRolesResponse:
+      items:
+        $ref: '#/components/schemas/Role'
+      nullable: true
+      type: array
+    ListServiceAccountsResponse:
+      items:
+        $ref: '#/components/schemas/ServiceAccount'
+      nullable: true
+      type: array
+    ListTokensResponse:
+      items:
+        $ref: '#/components/schemas/Token'
+      nullable: true
+      type: array
+    PermissionExprMap:
+      properties:
+        authzed.v1/BulkCheckPermission:
+          type: string
+        authzed.v1/BulkExportRelationships:
+          type: string
+        authzed.v1/BulkImportRelationships:
+          type: string
+        authzed.v1/CheckBulkPermissions:
+          type: string
+        authzed.v1/CheckPermission:
+          type: string
+        authzed.v1/ComputablePermissions:
+          type: string
+        authzed.v1/DeleteRelationships:
+          type: string
+        authzed.v1/DependentRelations:
+          type: string
+        authzed.v1/DiffSchema:
+          type: string
+        authzed.v1/ExpandPermissionTree:
+          type: string
+        authzed.v1/ExperimentalComputablePermissions:
+          type: string
+        authzed.v1/ExperimentalCountRelationships:
+          type: string
+        authzed.v1/ExperimentalDependentRelations:
+          type: string
+        authzed.v1/ExperimentalDiffSchema:
+          type: string
+        authzed.v1/ExperimentalReflectSchema:
+          type: string
+        authzed.v1/ExperimentalRegisterRelationshipCounter:
+          type: string
+        authzed.v1/ExperimentalUnregisterRelationshipCounter:
+          type: string
+        authzed.v1/ExportBulkRelationships:
+          type: string
+        authzed.v1/ImportBulkRelationships:
+          type: string
+        authzed.v1/LookupResources:
+          type: string
+        authzed.v1/LookupSubjects:
+          type: string
+        authzed.v1/ReadRelationships:
+          type: string
+        authzed.v1/ReadSchema:
+          type: string
+        authzed.v1/ReflectSchema:
+          type: string
+        authzed.v1/Watch:
+          type: string
+        authzed.v1/WriteRelationships:
+          type: string
+        authzed.v1/WriteSchema:
+          type: string
+    PermissionSystem:
+      properties:
+        globalDnsPath:
+          description: The global DNS path for the Permission System
+          type: string
+        id:
+          description: The globally unique ID for this Permission System
+          type: string
+        name:
+          description: The name of the Permission System
+          type: string
+        systemState:
+          $ref: '#/components/schemas/PermissionsSystemState'
+        systemType:
+          description: The type of the Permission System, either 'development' or
+            'production'
+          type: string
+        version:
+          $ref: '#/components/schemas/SystemVersion'
+      type: object
+    PermissionsSystemState:
       properties:
         message:
+          description: The message associated with the status
           type: string
-        owner:
+        status:
+          description: The status of the Permission System
           type: string
+      type: object
+    Policy:
+      properties:
+        createdAt:
+          description: The timestamp when the Policy was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Policy. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Policy. May be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Policy
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Policy
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        principalID:
+          description: The ID of the Principal that this Policy is associated with
+          type: string
+        roleIDs:
+          description: The IDs of the Roles that this Policy is associated with. Currently
+            only allowed to be a single ID
+          items:
+            type: string
+          maxLength: 1
+          minLength: 1
+          type: array
+      required:
+      - permissionSystemID
+      - name
+      - principalID
+      - roleIDs
+      type: object
+    Role:
+      properties:
+        createdAt:
+          description: The timestamp when the Role was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Role. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Role. May be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Role
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Role
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        permissions:
+          $ref: '#/components/schemas/PermissionExprMap'
+      required:
+      - permissionSystemID
+      - name
+      - permissions
+      type: object
+    ServiceAccount:
+      properties:
+        createdAt:
+          description: The timestamp when the Service Account was created (RFC 3339).
+            May not be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Service Account. May
+            be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Service Account. May
+            be empty.
+          maxLength: 200
+          type: string
+        id:
+          description: The globally unique ID for this Service Account
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Service Account
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        token:
+          description: The Tokens associated with this Service Account
+          items:
+            $ref: '#/components/schemas/Token'
+          readOnly: true
+          type: array
+      required:
+      - permissionSystemID
+      - name
+      type: object
+    SpiceDBVersion:
+      properties:
+        displayName:
+          description: The display name of the version
+          type: string
+        supportedFeatureNames:
+          description: The features supported by the version
+          items:
+            type: string
+          type: array
+        version:
+          description: The version of SpiceDB
+          type: string
+      type: object
+    SystemVersion:
+      properties:
+        currentVersion:
+          $ref: '#/components/schemas/SpiceDBVersion'
+        hasUpdateAvailable:
+          description: Whether an update is available for the SpiceDB version
+          type: boolean
+        isLockedToVersion:
+          description: Whether the version is locked to a specific version or not
+          type: boolean
+        overrideImage:
+          description: The image to use for the SpiceDB instance. If not specified,
+            the default image for the channel will be used.
+          type: string
+        selectedChannel:
+          description: The channel selected for the SpiceDB version. May be empty.
+          type: string
+      type: object
+    Token:
+      properties:
+        createdAt:
+          description: The timestamp when the Token was created (RFC 3339). May not
+            be specified.
+          format: date-time
+          nullable: true
+          readOnly: true
+          type: string
+        creator:
+          description: The name of the user that created this Token. May be empty.
+          readOnly: true
+          type: string
+        description:
+          description: The human-supplied description of the Token. May be empty.
+          maxLength: 200
+          type: string
+        hash:
+          description: The SHA256 hash of the secret part of the token, without the
+            prefix
+          readOnly: true
+          type: string
+        id:
+          description: The globally unique ID for this Token
+          readOnly: true
+          type: string
+        name:
+          description: The name of the Token
+          maxLength: 50
+          minLength: 1
+          type: string
+        permissionSystemID:
+          description: The globally unique ID for the Permission System
+          type: string
+        serviceAccountID:
+          description: The globally unique ID for the containing Service Account
+          type: string
+      required:
+      - permissionSystemID
+      - serviceAccountID
+      - name
       type: object
   securitySchemes:
     auth:


### PR DESCRIPTION
After the API name change from Platform API to Cloud API, we had to update all the references in the terraform provider, which was a breaking change.

fixes: https://linear.app/authzed/issue/CTL-650/terraform-provider-update-all-references-to-cloud-api