### PR TITLE
refactor: rename provider and resources from cloud-api to cloudapi

### DIFF
--- a/.terraform-registry-manifest.json
+++ b/.terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["5.0"]
+  }
+} 

--- a/.tfrepo
+++ b/.tfrepo
@@ -1,0 +1,8 @@
+provider_installation {
+  network_mirror {
+    url = "https://terraform.releases.hashicorp.com"
+  }
+  direct {
+    exclude = ["registry.terraform.io/authzed/cloudapi"]
+  }
+} 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Changed
+- Renamed provider from `platform-api` to `cloudapi` for Terraform Registry compliance
+- Updated documentation to reflect new provider name
 - Improved README with more detailed examples
 
 ## [0.1.0] - 2023-08-15
@@ -20,5 +23,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Support for managing Policies
 - Documentation and examples
 
-[Unreleased]: https://github.com/authzed/terraform-provider-cloud-api/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/authzed/terraform-provider-cloud-api/releases/tag/v0.1.0 
+[Unreleased]: https://github.com/authzed/terraform-provider-cloudapi/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/authzed/terraform-provider-cloudapi/releases/tag/v0.1.0 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 1. **Fork the repository** on GitHub.
 2. **Clone your fork** locally:
    ```
-   git clone https://github.com/YOUR-USERNAME/terraform-provider-cloud-api.git
+   git clone https://github.com/YOUR-USERNAME/terraform-provider-cloudapi.git
    ```
 3. **Create a branch** for your work:
    ```
@@ -24,7 +24,7 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 - Go 1.23 or higher
 - Terraform 1.0 or higher
-- Access to an AuthZed Dedicated account for testing
+- Access to an AuthZed Cloud account for testing
 
 ### Building and Testing
 
@@ -40,8 +40,8 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 3. **Install locally for testing**:
    ```
-   mkdir -p ~/.terraform.d/plugins/registry.terraform.io/authzed/cloud-api/0.1.0/$(go env GOOS)_$(go env GOARCH)
-   cp terraform-provider-cloud-api ~/.terraform.d/plugins/registry.terraform.io/authzed/cloud-api/0.1.0/$(go env GOOS)_$(go env GOARCH)/
+   mkdir -p ~/.terraform.d/plugins/registry.terraform.io/authzed/cloudapi/0.1.0/$(go env GOOS)_$(go env GOARCH)
+   cp terraform-provider-cloudapi ~/.terraform.d/plugins/registry.terraform.io/authzed/cloudapi/0.1.0/$(go env GOOS)_$(go env GOARCH)/
    ```
 
 ## Making Changes
@@ -52,6 +52,13 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 - Use `go fmt` to format your code
 - Ensure your code passes `go vet` and `golint`
 
+### Commit Messages
+
+- Use the present tense ("Add feature" not "Added feature")
+- Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+- Limit the first line to 72 characters or less
+- Reference issues and pull requests liberally after the first line
+
 ### Pull Requests
 
 1. Update the README.md with details of changes if appropriate
@@ -59,6 +66,11 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 3. The PR should work against the main branch
 4. Include appropriate tests
 
+## Documentation
+
+- Update documentation to reflect any changes in functionality
+- Provide examples for new features
+- Keep the README and other documentation up to date
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ The AuthZed Cloud API Terraform Provider allows you to manage AuthZed Cloud reso
 
 ## Documentation
 
-Full documentation will soon be available on the Terraform Registry.
+Full documentation is available on the [Terraform Registry](https://registry.terraform.io/providers/authzed/cloudapi/latest/docs).
 
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.23.4
-- AuthZed Dedicated account
+- [Go](https://golang.org/doc/install) >= 1.23
+- AuthZed Cloud account
 
 ## Using the Provider
 
@@ -19,27 +19,27 @@ To use the provider in your Terraform configuration:
 ```hcl
 terraform {
   required_providers {
-    cloud-api = {
-      source  = "authzed/cloud-api"
+    cloudapi = {
+      source  = "authzed/cloudapi"
       version = "~> 0.1.0"
     }
   }
 }
 
-provider "cloud-api" {
+provider "cloudapi" {
   endpoint = "https://cloud.authzed.com/api"
   token    = "your-token"
 }
 
 # Example: Creating a service account
-resource "cloud-api_service_account" "api_service" {
+resource "cloudapi_service_account" "api_service" {
   name                 = "api-service"
   description          = "Service account for the API service"
   permission_system_id = "sys_123456789"
 }
 
 # Example: Creating a role
-resource "cloud-api_role" "reader" {
+resource "cloudapi_role" "reader" {
   name                 = "reader"
   description          = "Role for read-only operations"
   permission_system_id = "sys_123456789"
@@ -75,8 +75,8 @@ And data sources for retrieving:
 
 Clone the repository:
 ```bash
-git clone https://github.com/authzed/terraform-provider-cloud-api.git
-cd terraform-provider-cloud-api
+git clone https://github.com/authzed/terraform-provider-cloudapi.git
+cd terraform-provider-cloudapi
 go build
 ```
 
@@ -85,8 +85,8 @@ go build
 To install the provider locally for development:
 
 ```bash
-mkdir -p ~/.terraform.d/plugins/registry.terraform.io/authzed/cloud-api/0.1.0/$(go env GOOS)_$(go env GOARCH)
-cp terraform-provider-cloud-api ~/.terraform.d/plugins/registry.terraform.io/authzed/cloud-api/0.1.0/$(go env GOOS)_$(go env GOARCH)/
+mkdir -p ~/.terraform.d/plugins/registry.terraform.io/authzed/cloudapi/0.1.0/$(go env GOOS)_$(go env GOARCH)
+cp terraform-provider-cloudapi ~/.terraform.d/plugins/registry.terraform.io/authzed/cloudapi/0.1.0/$(go env GOOS)_$(go env GOARCH)/
 ```
 
 ### Using a Local Build in Terraform
@@ -96,7 +96,7 @@ To use the locally built provider, add a dev_overrides section to your ~/.terraf
 ```hcl
 provider_installation {
   dev_overrides {
-    "registry.terraform.io/authzed/cloud-api" = "/path/to/terraform-provider-cloud-api"
+    "registry.terraform.io/authzed/cloudapi" = "/path/to/terraform-provider-cloudapi"
   }
   direct {}
 }

--- a/dev.tfrc
+++ b/dev.tfrc
@@ -1,0 +1,1 @@
+provider_installation { dev_overrides { "registry.terraform.io/authzed/cloudapi" = "/Users/veronica/code/authzed/terraform-provider-platform-api" } direct {} }

--- a/internal/client/permission_system.go
+++ b/internal/client/permission_system.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"terraform-provider-cloud-api/internal/models"
+	"terraform-provider-cloudapi/internal/models"
 )
 
 // ListPermissionSystems retrieves all permission systems

--- a/internal/client/policy.go
+++ b/internal/client/policy.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"terraform-provider-cloud-api/internal/models"
+	"terraform-provider-cloudapi/internal/models"
 )
 
 // ListPolicies retrieves all policies for a permission system

--- a/internal/client/role.go
+++ b/internal/client/role.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"terraform-provider-cloud-api/internal/models"
+	"terraform-provider-cloudapi/internal/models"
 )
 
 // ListRoles retrieves all roles for a ps

--- a/internal/client/service_account.go
+++ b/internal/client/service_account.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"terraform-provider-cloud-api/internal/models"
+	"terraform-provider-cloudapi/internal/models"
 )
 
 func (c *CloudClient) ListServiceAccounts(permissionSystemID string) ([]models.ServiceAccount, error) {

--- a/internal/client/token.go
+++ b/internal/client/token.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"terraform-provider-cloud-api/internal/models"
+	"terraform-provider-cloudapi/internal/models"
 )
 
 func (c *CloudClient) CreateToken(token *models.Token) (*models.Token, error) {

--- a/internal/provider/permission_system_data_source.go
+++ b/internal/provider/permission_system_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"

--- a/internal/provider/permission_systems_data_source.go
+++ b/internal/provider/permission_systems_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/internal/provider/policies_data_source.go
+++ b/internal/provider/policies_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/internal/provider/policy_data_source.go
+++ b/internal/provider/policy_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
-	"terraform-provider-cloud-api/internal/models"
+	"terraform-provider-cloudapi/internal/client"
+	"terraform-provider-cloudapi/internal/models"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/internal/provider/role_data_source.go
+++ b/internal/provider/role_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
-	"terraform-provider-cloud-api/internal/models"
+	"terraform-provider-cloudapi/internal/client"
+	"terraform-provider-cloudapi/internal/models"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/internal/provider/roles_data_source.go
+++ b/internal/provider/roles_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/internal/provider/service_account_data_source.go
+++ b/internal/provider/service_account_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
-	"terraform-provider-cloud-api/internal/models"
+	"terraform-provider-cloudapi/internal/client"
+	"terraform-provider-cloudapi/internal/models"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/internal/provider/service_accounts_data_source.go
+++ b/internal/provider/service_accounts_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/internal/provider/token_data_source.go
+++ b/internal/provider/token_data_source.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -3,8 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
-	"terraform-provider-cloud-api/internal/client"
-	"terraform-provider-cloud-api/internal/models"
+	"terraform-provider-cloudapi/internal/client"
+	"terraform-provider-cloudapi/internal/models"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/internal/provider/tokens_data_source.go
+++ b/internal/provider/tokens_data_source.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/list_permission_systems.go
+++ b/list_permission_systems.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"terraform-provider-cloud-api/internal/client"
+	"terraform-provider-cloudapi/internal/client"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"terraform-provider-cloud-api/internal/provider"
+	"terraform-provider-cloudapi/internal/provider"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
@@ -25,7 +25,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		Address: "registry.terraform.io/authzed/cloud-api",
+		Address: "registry.terraform.io/authzed/cloudapi",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
renaming resources and references to from `cloud-api` to `cloudapi` to honour the tf naming conventions