### PR TITLE
fix: improve client-side ETag handling and update operations

### DIFF
--- a/internal/client/cloud_client.go
+++ b/internal/client/cloud_client.go
@@ -102,7 +102,8 @@ func (c *CloudClient) Do(req *http.Request) (*ResponseWithETag, error) {
 func (c *CloudClient) UpdateResource(resource Resource, endpoint string, body any) (Resource, error) {
 	// Check if the ETag is empty
 	if resource.GetETag() == "" {
-		// Get the current resource to obtain an ETag
+		// We only update the ETag, not the local attributes, since this is purely for optconcurrency control.
+		// If the remote resource differs from local state, the update will fail with 412 and retry with latest version.
 		req, err := c.NewRequest(http.MethodGet, endpoint, nil)
 		if err != nil {
 			return nil, err

--- a/internal/client/cloud_client.go
+++ b/internal/client/cloud_client.go
@@ -102,7 +102,8 @@ func (c *CloudClient) Do(req *http.Request) (*ResponseWithETag, error) {
 func (c *CloudClient) UpdateResource(resource Resource, endpoint string, body any) (Resource, error) {
 	// Check if the ETag is empty
 	if resource.GetETag() == "" {
-		// We only update the ETag, not the local attributes, since this is purely for optconcurrency control.
+		// We only update the ETag without updating local attributes. ETags represent specific
+		// versions of resources (like a hash) and this is purely for optimistic concurrency control.
 		// If the remote resource differs from local state, the update will fail with 412 and retry with latest version.
 		req, err := c.NewRequest(http.MethodGet, endpoint, nil)
 		if err != nil {

--- a/internal/client/cloud_client.go
+++ b/internal/client/cloud_client.go
@@ -91,8 +91,52 @@ func (c *CloudClient) Do(req *http.Request) (*ResponseWithETag, error) {
 		return nil, err
 	}
 
-	// Extract the ETag if it exists
-	etag := resp.Header.Get("ETag")
+	// Extract the ETag - check multiple possible header names
+	var etag string
+
+	// Check standard ETag header (case-insensitive)
+	etag = resp.Header.Get("ETag")
+
+	// If not found, check for other variations
+	if etag == "" {
+		etag = resp.Header.Get("etag")
+	}
+	if etag == "" {
+		etag = resp.Header.Get("Etag")
+	}
+
+	// Sometimes ETags are returned with quotes, clean those if present
+	if len(etag) > 0 && (etag[0] == '"' && etag[len(etag)-1] == '"') {
+		etag = etag[1 : len(etag)-1]
+	}
+
+	// If ETag is still not found, try to extract it from the response body
+	if etag == "" && (resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated) {
+		// Only attempt this for successful responses
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err == nil {
+			// Create a copy of the body for later use
+			resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+			// Try to find ETag in a common field pattern
+			var respMap map[string]interface{}
+			if err := json.Unmarshal(bodyBytes, &respMap); err == nil {
+				// Check for common ETag field patterns in the response
+				if etagVal, ok := respMap["etag"].(string); ok {
+					etag = etagVal
+				} else if etagVal, ok := respMap["ETag"].(string); ok {
+					etag = etagVal
+				} else if etagVal, ok := respMap["e_tag"].(string); ok {
+					etag = etagVal
+				} else if etagVal, ok := respMap["_etag"].(string); ok {
+					etag = etagVal
+				} else if etagVal, ok := respMap["ConfigETag"].(string); ok {
+					// This is the format used by the AuthZed API
+					etag = etagVal
+				}
+			}
+		}
+	}
 
 	return &ResponseWithETag{
 		Response: resp,
@@ -102,6 +146,37 @@ func (c *CloudClient) Do(req *http.Request) (*ResponseWithETag, error) {
 
 // UpdateResource updates any resource that implements the Resource interface
 func (c *CloudClient) UpdateResource(resource Resource, endpoint string, body any) (Resource, error) {
+	// Check if the ETag is empty
+	if resource.GetETag() == "" {
+		fmt.Printf("Warning: Empty ETag provided for update operation. Attempting to fetch current ETag first.\n")
+
+		// Get the current resource to obtain an ETag
+		req, err := c.NewRequest(http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		respWithETag, err := c.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if respWithETag.Response.StatusCode != http.StatusOK {
+			_ = respWithETag.Response.Body.Close()
+			return nil, fmt.Errorf("failed to fetch current resource for ETag: %s", NewAPIError(respWithETag))
+		}
+
+		// Extract the ETag from the GET response
+		etag := respWithETag.ETag
+		fmt.Printf("Retrieved ETag %q for update operation\n", etag)
+
+		// Set the ETag on the resource
+		resource.SetETag(etag)
+
+		_ = respWithETag.Response.Body.Close()
+	}
+
+	// Proceed with the update using the ETag (original or newly fetched)
 	req, err := c.NewRequest(http.MethodPut, endpoint, body, WithETag(resource.GetETag()))
 	if err != nil {
 		return nil, err
@@ -259,6 +334,40 @@ func (c *CloudClient) CreateResourceWithFactory(endpoint string, body any, dest 
 
 	if err := json.NewDecoder(respWithETag.Response.Body).Decode(dest); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// If no ETag was extracted, try to get it directly from the resource after creation
+	if respWithETag.ETag == "" {
+		fmt.Printf("No ETag found in response headers after resource creation. Attempting to fetch resource to get ETag.\n")
+
+		// Extract ID from the created resource to fetch it
+		// This requires some reflection or type assertion to get the ID
+		// For simplicity, we'll use the factory to create a resource first
+		resource := factory(dest, "")
+
+		// Get the resource ID
+		resID := resource.GetID()
+
+		if resID != "" {
+			// Use the ID to construct the GET endpoint
+			// This is a bit of a hack, since we're assuming the GET endpoint is the same as the POST endpoint + /{id}
+			getEndpoint := fmt.Sprintf("%s/%s", endpoint, resID)
+
+			// Make a GET request to fetch the resource with its ETag
+			getReq, err := c.NewRequest(http.MethodGet, getEndpoint, nil)
+			if err == nil {
+				getResp, err := c.Do(getReq)
+				if err == nil && getResp.Response.StatusCode == http.StatusOK {
+					// Successfully fetched, use the ETag from this response
+					if getResp.ETag != "" {
+						respWithETag.ETag = getResp.ETag
+						fmt.Printf("Retrieved ETag %q after fetching created resource\n", getResp.ETag)
+					}
+
+					_ = getResp.Response.Body.Close()
+				}
+			}
+		}
 	}
 
 	// Use the factory to create a Resource from the decoded object

--- a/internal/client/factories.go
+++ b/internal/client/factories.go
@@ -1,6 +1,8 @@
 package client
 
-import "terraform-provider-authzed/internal/models"
+import (
+	"terraform-provider-authzed/internal/models"
+)
 
 // NewServiceAccountResource creates a ServiceAccountWithETag Resource
 func NewServiceAccountResource(decoded any, etag string) Resource {
@@ -8,6 +10,12 @@ func NewServiceAccountResource(decoded any, etag string) Resource {
 	if !ok {
 		panic("Invalid type for ServiceAccount")
 	}
+
+	// If etag is empty and the service account has a ConfigETag, use that
+	if etag == "" && serviceAccount.ConfigETag != "" {
+		etag = serviceAccount.ConfigETag
+	}
+
 	return &ServiceAccountWithETag{
 		ServiceAccount: serviceAccount,
 		ETag:           etag,
@@ -20,6 +28,12 @@ func NewRoleResource(decoded any, etag string) Resource {
 	if !ok {
 		panic("Invalid type for Role")
 	}
+
+	// If etag is empty and the role has a ConfigETag, use that
+	if etag == "" && role.ConfigETag != "" {
+		etag = role.ConfigETag
+	}
+
 	return &RoleWithETag{
 		Role: role,
 		ETag: etag,
@@ -32,6 +46,12 @@ func NewPolicyResource(decoded any, etag string) Resource {
 	if !ok {
 		panic("Invalid type for Policy")
 	}
+
+	// If etag is empty and the policy has a ConfigETag, use that
+	if etag == "" && policy.ConfigETag != "" {
+		etag = policy.ConfigETag
+	}
+
 	return &PolicyWithETag{
 		Policy: policy,
 		ETag:   etag,

--- a/internal/client/policy.go
+++ b/internal/client/policy.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"terraform-provider-authzed/internal/models"
@@ -91,21 +93,101 @@ func (c *CloudClient) CreatePolicy(policy *models.Policy) (*PolicyWithETag, erro
 	return resource.(*PolicyWithETag), nil
 }
 
-// UpdatePolicy updates an existing policy using the PUT method
+// UpdatePolicy updates an existing policy
 func (c *CloudClient) UpdatePolicy(policy *models.Policy, etag string) (*PolicyWithETag, error) {
 	path := fmt.Sprintf("/ps/%s/access/policies/%s", policy.PermissionsSystemID, policy.ID)
 
-	resourceWrapper := &PolicyWithETag{
-		Policy: policy,
-		ETag:   etag,
-	}
-
-	updatedResource, err := c.UpdateResource(resourceWrapper, path, policy)
+	// Create a direct PUT request without using UpdateResource
+	req, err := c.NewRequest(http.MethodPut, path, policy)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	return updatedResource.(*PolicyWithETag), nil
+	// Only set If-Match header if we have a non-empty ETag
+	if etag != "" {
+		req.Header.Set("If-Match", etag)
+	}
+
+	respWithETag, err := c.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	// Keep the response body for potential error reporting
+	var respBody []byte
+	if respWithETag.Response.Body != nil {
+		respBody, _ = io.ReadAll(respWithETag.Response.Body)
+		// Replace the body for further use
+		respWithETag.Response.Body = io.NopCloser(bytes.NewBuffer(respBody))
+	}
+
+	defer func() {
+		if respWithETag.Response.Body != nil {
+			_ = respWithETag.Response.Body.Close()
+		}
+	}()
+
+	if respWithETag.Response.StatusCode != http.StatusOK {
+		// If it's a 404 error, attempt to recreate the resource
+		if respWithETag.Response.StatusCode == http.StatusNotFound {
+			// Recreate the policy using POST to the base endpoint
+			createPath := fmt.Sprintf("/ps/%s/access/policies", policy.PermissionsSystemID)
+			originalID := policy.ID
+
+			createReq, err := c.NewRequest(http.MethodPost, createPath, policy)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create request for recreation: %w", err)
+			}
+
+			createResp, err := c.Do(createReq)
+			if err != nil {
+				return nil, fmt.Errorf("failed to send create request for recreation: %w", err)
+			}
+
+			defer func() {
+				if createResp.Response.Body != nil {
+					_ = createResp.Response.Body.Close()
+				}
+			}()
+
+			if createResp.Response.StatusCode != http.StatusCreated {
+				return nil, fmt.Errorf("failed to recreate policy: %s", NewAPIError(createResp))
+			}
+
+			// Decode the created policy
+			var createdPolicy models.Policy
+			if err := json.NewDecoder(createResp.Response.Body).Decode(&createdPolicy); err != nil {
+				return nil, fmt.Errorf("failed to decode recreated policy: %w", err)
+			}
+
+			// Create the result with the original ID to maintain consistency
+			result := &PolicyWithETag{
+				Policy: &createdPolicy,
+				ETag:   createResp.ETag,
+			}
+
+			// Force the right ID to maintain Terraform state consistency
+			if result.Policy.ID != originalID {
+				result.Policy.ID = originalID
+			}
+
+			return result, nil
+		}
+
+		return nil, fmt.Errorf("failed to update policy: %s", NewAPIError(respWithETag))
+	}
+
+	// Decode the updated policy from the response
+	var updatedPolicy models.Policy
+	if err := json.NewDecoder(io.NopCloser(bytes.NewBuffer(respBody))).Decode(&updatedPolicy); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// Create and return the wrapped policy with ETag
+	return &PolicyWithETag{
+		Policy: &updatedPolicy,
+		ETag:   respWithETag.ETag,
+	}, nil
 }
 
 // DeletePolicy deletes a policy by its ID

--- a/internal/client/policy.go
+++ b/internal/client/policy.go
@@ -93,7 +93,7 @@ func (c *CloudClient) CreatePolicy(policy *models.Policy) (*PolicyWithETag, erro
 	return resource.(*PolicyWithETag), nil
 }
 
-// UpdatePolicy updates an existing policy
+// UpdatePolicy updates an existing policy using the PUT method
 func (c *CloudClient) UpdatePolicy(policy *models.Policy, etag string) (*PolicyWithETag, error) {
 	path := fmt.Sprintf("/ps/%s/access/policies/%s", policy.PermissionsSystemID, policy.ID)
 
@@ -151,7 +151,7 @@ func (c *CloudClient) UpdatePolicy(policy *models.Policy, etag string) (*PolicyW
 			}()
 
 			if createResp.Response.StatusCode != http.StatusCreated {
-				return nil, fmt.Errorf("failed to recreate policy: %s", NewAPIError(createResp))
+				return nil, NewAPIError(createResp)
 			}
 
 			// Decode the created policy
@@ -174,7 +174,7 @@ func (c *CloudClient) UpdatePolicy(policy *models.Policy, etag string) (*PolicyW
 			return result, nil
 		}
 
-		return nil, fmt.Errorf("failed to update policy: %s", NewAPIError(respWithETag))
+		return nil, NewAPIError(respWithETag)
 	}
 
 	// Decode the updated policy from the response

--- a/internal/client/role.go
+++ b/internal/client/role.go
@@ -102,7 +102,7 @@ func (c *CloudClient) CreateRole(role *models.Role) (*RoleWithETag, error) {
 	return resource.(*RoleWithETag), nil
 }
 
-// UpdateRole updates an existing role
+// UpdateRole updates an existing role using the PUT method
 func (c *CloudClient) UpdateRole(role *models.Role, etag string) (*RoleWithETag, error) {
 	path := fmt.Sprintf("/ps/%s/access/roles/%s", role.PermissionsSystemID, role.ID)
 
@@ -160,7 +160,7 @@ func (c *CloudClient) UpdateRole(role *models.Role, etag string) (*RoleWithETag,
 			}()
 
 			if createResp.Response.StatusCode != http.StatusCreated {
-				return nil, fmt.Errorf("failed to recreate role: %s", NewAPIError(createResp))
+				return nil, NewAPIError(createResp)
 			}
 
 			// Decode the created role
@@ -183,7 +183,7 @@ func (c *CloudClient) UpdateRole(role *models.Role, etag string) (*RoleWithETag,
 			return result, nil
 		}
 
-		return nil, fmt.Errorf("failed to update role: %s", NewAPIError(respWithETag))
+		return nil, NewAPIError(respWithETag)
 	}
 
 	// Decode the updated role from the response

--- a/internal/client/service_account.go
+++ b/internal/client/service_account.go
@@ -178,7 +178,7 @@ func (c *CloudClient) UpdateServiceAccount(serviceAccount *models.ServiceAccount
 			}()
 
 			if createResp.Response.StatusCode != http.StatusCreated {
-				return nil, fmt.Errorf("failed to recreate service account: %s", NewAPIError(createResp))
+				return nil, NewAPIError(createResp)
 			}
 
 			// Decode the created service account
@@ -201,7 +201,7 @@ func (c *CloudClient) UpdateServiceAccount(serviceAccount *models.ServiceAccount
 			return result, nil
 		}
 
-		return nil, fmt.Errorf("failed to update service account: %s", NewAPIError(respWithETag))
+		return nil, NewAPIError(respWithETag)
 	}
 
 	// Decode the updated service account from the response

--- a/internal/client/test/etag_test.go
+++ b/internal/client/test/etag_test.go
@@ -137,9 +137,12 @@ func TestETagSupport(t *testing.T) {
 		assert.True(t, ifMatchHeaderReceived, "If-Match header should be sent")
 		assert.Equal(t, "W/\"wrong-etag\"", receivedETag, "Wrong ETag should be sent")
 
-		// Check error type
 		apiErr, ok := err.(*client.APIError)
 		assert.True(t, ok, "Error should be an APIError")
-		assert.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode, "Should receive 412 Precondition Failed")
+
+		// Only check status code if we have a valid APIError
+		if ok && apiErr != nil {
+			assert.Equal(t, http.StatusPreconditionFailed, apiErr.StatusCode, "Should receive 412 Precondition Failed")
+		}
 	})
 }

--- a/internal/client/test/etag_test.go
+++ b/internal/client/test/etag_test.go
@@ -17,7 +17,7 @@ func TestETagSupport(t *testing.T) {
 	var receivedETag string
 	var firstReceivedETag string // Track the first ETag received for verification
 	var ifMatchHeaderReceived bool
-	var firstPUTRequest bool = true // Track first PUT request for retry test
+	var firstPUTRequest = true // Track first PUT request for retry test
 
 	// Create test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/models/policy.go
+++ b/internal/models/policy.go
@@ -1,5 +1,6 @@
 package models
 
+// Policy represents a permission policy in a permissions system
 type Policy struct {
 	ID                  string   `json:"id,omitempty"`
 	Name                string   `json:"name"`
@@ -9,4 +10,5 @@ type Policy struct {
 	RoleIDs             []string `json:"roleIDs"`
 	CreatedAt           string   `json:"createdAt,omitempty"`
 	Creator             string   `json:"creator,omitempty"`
+	ConfigETag          string   `json:"ConfigETag,omitempty"`
 }

--- a/internal/models/role.go
+++ b/internal/models/role.go
@@ -1,13 +1,15 @@
 package models
 
+// Role represents a permission role in a permissions system
 type Role struct {
-	ID                  string            `json:"id"`
+	ID                  string            `json:"id,omitempty"`
+	PermissionsSystemID string            `json:"permissionsSystemID"`
 	Name                string            `json:"name"`
 	Description         string            `json:"description,omitempty"`
-	PermissionsSystemID string            `json:"permissionsSystemID"`
-	Permissions         PermissionExprMap `json:"permissions"`
+	Permissions         PermissionExprMap `json:"permissions,omitempty"`
 	CreatedAt           string            `json:"createdAt,omitempty"`
 	Creator             string            `json:"creator,omitempty"`
+	ConfigETag          string            `json:"ConfigETag,omitempty"`
 }
 
 type PermissionExprMap map[string]string

--- a/internal/models/role.go
+++ b/internal/models/role.go
@@ -9,7 +9,7 @@ type Role struct {
 	Permissions         PermissionExprMap `json:"permissions,omitempty"`
 	CreatedAt           string            `json:"createdAt,omitempty"`
 	Creator             string            `json:"creator,omitempty"`
-	ConfigETag          string            `json:"ConfigETag,omitempty"`
+	ConfigETag          string            `json:"configETag,omitempty"`
 }
 
 type PermissionExprMap map[string]string

--- a/internal/models/service_account.go
+++ b/internal/models/service_account.go
@@ -9,7 +9,7 @@ type ServiceAccount struct {
 	Tokens              []Token `json:"token,omitempty"`
 	CreatedAt           string  `json:"createdAt,omitempty"`
 	Creator             string  `json:"creator,omitempty"`
-	ConfigETag          string  `json:"ConfigETag,omitempty"`
+	ConfigETag          string  `json:"configETag,omitempty"`
 }
 
 // Token represents a token associated with a service account

--- a/internal/models/service_account.go
+++ b/internal/models/service_account.go
@@ -9,6 +9,7 @@ type ServiceAccount struct {
 	Tokens              []Token `json:"token,omitempty"`
 	CreatedAt           string  `json:"createdAt,omitempty"`
 	Creator             string  `json:"creator,omitempty"`
+	ConfigETag          string  `json:"ConfigETag,omitempty"`
 }
 
 // Token represents a token associated with a service account

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"terraform-provider-authzed/internal/client"
 	"terraform-provider-authzed/internal/models"
@@ -138,6 +139,13 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	roleWithETag, err := r.client.GetRole(data.PermissionsSystemID.ValueString(), data.ID.ValueString())
 	if err != nil {
+		// Check if the resource was not found (404 error)
+		if strings.Contains(err.Error(), "status 404") || strings.Contains(err.Error(), "not found") {
+			// Resource no longer exists, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read role, got error: %s", err))
 		return
 	}
@@ -199,6 +207,13 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Update resource data with the response
+	data.ID = types.StringValue(updatedRoleWithETag.Role.ID)
+
+	// If the ID is empty, preserve the original ID
+	if data.ID.ValueString() == "" {
+		data.ID = state.ID
+	}
+
 	data.CreatedAt = types.StringValue(updatedRoleWithETag.Role.CreatedAt)
 	data.Creator = types.StringValue(updatedRoleWithETag.Role.Creator)
 	data.ETag = types.StringValue(updatedRoleWithETag.ETag)


### PR DESCRIPTION
in this pr I modified the client code to properly extract ETags from both http headers and the `ConfigETag` field in response bodies.
Also added better error handling for 404 responses and implemented fallback logic to recreate resources when necessary. This makes Updates more reliable and ensure ETags are properly managed throughout the tf resource lifecycle.