### PR TITLE
docs: reflect Updates support; align docs with OpenAPI spec

### DIFF
--- a/docs/data-sources/permission_system.md
+++ b/docs/data-sources/permission_system.md
@@ -32,20 +32,23 @@ output "system_type" {
 
 The following attributes are exported:
 
-* `name` - The name of the permission system. Will be between 1 and 50 characters.
-* `description` - The description of the permission system. Maximum length is 200 characters.
-* `system_type` - The type of the permission system (e.g., "dedicated", "developer").
-* `created_at` - The timestamp when the permission system was created (RFC 3339 format).
-* `creator` - The name of the user that created this permission system.
-* `updated_at` - The timestamp when the permission system was last updated (RFC 3339 format).
-* `updater` - The name of the user that last updated this permission system.
-* `version` - A complex object containing version information with the following attributes:
-  * `current_version` - An object containing:
-    * `display_name` - The display name of the current version.
-    * `supported_feature_names` - List of supported feature names.
-    * `version` - The version string.
-  * `has_update_available` - Whether an update is available.
-  * `is_locked_to_version` - Whether the version is locked.
-  * `override_image` - The image to use for the SpiceDB instance.
-  * `selected_channel` - The selected channel for updates.
+* `name` - The name of the permission system.
+* `system_type` - The type of the permission system ("development" or "production").
+* `system_state` - Information about the current state of the permission system:
+  * `status` - The operational status of the system. Possible values: "CLUSTER_ISSUE", "DEGRADED", "MODIFYING", "PAUSED", "PROVISIONING", "PROVISION_ERROR", "RUNNING", "UNKNOWN", "UPGRADE_ERROR", "UPGRADING".
+  * `message` - A human-readable message explaining the current state.
+* `version` - Version information for the permission system:
+  * `current_version` - Information about the current SpiceDB version:
+    * `display_name` - The display name of the version.
+    * `supported_feature_names` - List of features supported by this version.
+    * `version` - The version of SpiceDB.
+  * `has_update_available` - Whether an update is available for the SpiceDB version.
+  * `is_locked_to_version` - Whether the version is locked to a specific version.
+  * `override_image` - The image to use for the SpiceDB instance (if specified).
+  * `selected_channel` - The channel selected for the SpiceDB version.
+  * `selected_channel_display_name` - The display name of the selected channel.
+* `features` - List of features enabled in this permission system. Each feature contains:
+  * `id` - The feature identifier.
+  * `display_name` - The display name for the feature.
+  * `enabled` - Whether the feature is enabled or disabled.
 

--- a/docs/data-sources/permission_system.md
+++ b/docs/data-sources/permission_system.md
@@ -12,7 +12,7 @@ This data source retrieves information about a specific permission system in you
 
 ```terraform
 data "cloudapi_permission_system" "development" {
-  id = "sys_123456789"
+  id = "ps-123456789"
 }
 
 output "system_name" {
@@ -26,14 +26,26 @@ output "system_type" {
 
 ## Argument Reference
 
-* `id` - (Required) The unique identifier of the permission system to retrieve.
+* `id` - (Required) The unique identifier of the permission system to retrieve. Must start with `ps-` followed by alphanumeric characters or hyphens.
 
 ## Attribute Reference
 
 The following attributes are exported:
 
-* `name` - The name of the permission system.
+* `name` - The name of the permission system. Will be between 1 and 50 characters.
+* `description` - The description of the permission system. Maximum length is 200 characters.
 * `system_type` - The type of the permission system (e.g., "dedicated", "developer").
-* `created_at` - The timestamp when the permission system was created.
-* `updated_at` - The timestamp when the permission system was last updated.
+* `created_at` - The timestamp when the permission system was created (RFC 3339 format).
+* `creator` - The name of the user that created this permission system.
+* `updated_at` - The timestamp when the permission system was last updated (RFC 3339 format).
+* `updater` - The name of the user that last updated this permission system.
+* `version` - A complex object containing version information with the following attributes:
+  * `current_version` - An object containing:
+    * `display_name` - The display name of the current version.
+    * `supported_feature_names` - List of supported feature names.
+    * `version` - The version string.
+  * `has_update_available` - Whether an update is available.
+  * `is_locked_to_version` - Whether the version is locked.
+  * `override_image` - The image to use for the SpiceDB instance.
+  * `selected_channel` - The selected channel for updates.
 

--- a/docs/data-sources/permission_systems.md
+++ b/docs/data-sources/permission_systems.md
@@ -27,9 +27,21 @@ output "system_count" {
 The following attributes are exported:
 
 * `permission_systems` - A list of all permission systems. Each permission system contains:
-  * `id` - The unique identifier of the permission system.
-  * `name` - The name of the permission system.
+  * `id` - The unique identifier of the permission system. Will start with `ps-` followed by alphanumeric characters or hyphens.
+  * `name` - The name of the permission system. Will be between 1 and 50 characters.
+  * `description` - The description of the permission system. Maximum length is 200 characters.
   * `system_type` - The type of the permission system (e.g., "dedicated", "developer").
-  * `created_at` - The timestamp when the permission system was created.
-  * `updated_at` - The timestamp when the permission system was last updated.
+  * `created_at` - The timestamp when the permission system was created (RFC 3339 format).
+  * `creator` - The name of the user that created this permission system.
+  * `updated_at` - The timestamp when the permission system was last updated (RFC 3339 format).
+  * `updater` - The name of the user that last updated this permission system.
+  * `version` - A complex object containing version information with the following attributes:
+    * `current_version` - An object containing:
+      * `display_name` - The display name of the current version.
+      * `supported_feature_names` - List of supported feature names.
+      * `version` - The version string.
+    * `has_update_available` - Whether an update is available.
+    * `is_locked_to_version` - Whether the version is locked.
+    * `override_image` - The image to use for the SpiceDB instance.
+    * `selected_channel` - The selected channel for updates.
 * `permission_systems_count` - The total number of permission systems found. 

--- a/docs/data-sources/permission_systems.md
+++ b/docs/data-sources/permission_systems.md
@@ -27,21 +27,24 @@ output "system_count" {
 The following attributes are exported:
 
 * `permission_systems` - A list of all permission systems. Each permission system contains:
-  * `id` - The unique identifier of the permission system. Will start with `ps-` followed by alphanumeric characters or hyphens.
-  * `name` - The name of the permission system. Will be between 1 and 50 characters.
-  * `description` - The description of the permission system. Maximum length is 200 characters.
-  * `system_type` - The type of the permission system (e.g., "dedicated", "developer").
-  * `created_at` - The timestamp when the permission system was created (RFC 3339 format).
-  * `creator` - The name of the user that created this permission system.
-  * `updated_at` - The timestamp when the permission system was last updated (RFC 3339 format).
-  * `updater` - The name of the user that last updated this permission system.
-  * `version` - A complex object containing version information with the following attributes:
-    * `current_version` - An object containing:
-      * `display_name` - The display name of the current version.
-      * `supported_feature_names` - List of supported feature names.
-      * `version` - The version string.
-    * `has_update_available` - Whether an update is available.
-    * `is_locked_to_version` - Whether the version is locked.
-    * `override_image` - The image to use for the SpiceDB instance.
-    * `selected_channel` - The selected channel for updates.
-* `permission_systems_count` - The total number of permission systems found. 
+  * `id` - The unique identifier of the permission system. Must start with `ps-` followed by alphanumeric characters or hyphens.
+  * `name` - The name of the permission system.
+  * `system_type` - The type of the permission system ("development" or "production").
+  * `system_state` - Information about the current state of the permission system:
+    * `status` - The operational status of the system. Possible values: "CLUSTER_ISSUE", "DEGRADED", "MODIFYING", "PAUSED", "PROVISIONING", "PROVISION_ERROR", "RUNNING", "UNKNOWN", "UPGRADE_ERROR", "UPGRADING".
+    * `message` - A human-readable message explaining the current state.
+  * `version` - Version information for the permission system:
+    * `current_version` - Information about the current SpiceDB version:
+      * `display_name` - The display name of the version.
+      * `supported_feature_names` - List of features supported by this version.
+      * `version` - The version of SpiceDB.
+    * `has_update_available` - Whether an update is available for the SpiceDB version.
+    * `is_locked_to_version` - Whether the version is locked to a specific version.
+    * `override_image` - The image to use for the SpiceDB instance (if specified).
+    * `selected_channel` - The channel selected for the SpiceDB version.
+    * `selected_channel_display_name` - The display name of the selected channel.
+  * `features` - List of features enabled in this permission system. Each feature contains:
+    * `id` - The feature identifier.
+    * `display_name` - The display name for the feature.
+    * `enabled` - Whether the feature is enabled or disabled.
+* `permission_systems_count` - The total number of permission systems.

--- a/docs/data-sources/policy.md
+++ b/docs/data-sources/policy.md
@@ -12,8 +12,8 @@ This data source retrieves information about a specific policy in an AuthZed per
 
 ```terraform
 data "cloudapi_policy" "example" {
-  permission_system_id = "sys_123456789"
-  policy_id            = "pol_abcdef123456"
+  permission_system_id = "ps-123456789"
+  policy_id            = "apc-abcdef123456"
 }
 
 output "policy_roles" {
@@ -25,17 +25,19 @@ output "policy_roles" {
 
 The following arguments are supported:
 
-* `permission_system_id` - (Required) The ID of the permission system containing the policy.
-* `policy_id` - (Required) The ID of the policy to look up.
+* `permission_system_id` - (Required) The ID of the permission system containing the policy. Must start with `ps-` followed by alphanumeric characters or hyphens.
+* `policy_id` - (Required) The ID of the policy to look up. Must start with `apc-` followed by alphanumeric characters or hyphens.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - A composite ID uniquely identifying this policy.
-* `name` - The name of the policy.
-* `description` - The description of the policy.
+* `name` - The name of the policy. Will be between 1 and 50 characters.
+* `description` - The description of the policy. Maximum length is 200 characters.
 * `principal_id` - The ID of the service account this policy applies to.
-* `role_ids` - A list of role IDs assigned by this policy.
-* `created_at` - The timestamp when the policy was created.
-* `updated_at` - The timestamp when the policy was last updated. 
+* `role_ids` - A list of role IDs assigned by this policy. Currently limited to exactly one role ID.
+* `created_at` - The timestamp when the policy was created (RFC 3339 format).
+* `creator` - The name of the user that created this policy.
+* `updated_at` - The timestamp when the policy was last updated (RFC 3339 format).
+* `updater` - The name of the user that last updated this policy. 

--- a/docs/data-sources/role.md
+++ b/docs/data-sources/role.md
@@ -12,8 +12,8 @@ This data source retrieves information about a specific role in an AuthZed permi
 
 ```terraform
 data "cloudapi_role" "example" {
-  permission_system_id = "sys_123456789"
-  role_id              = "rol_abcdef123456"
+  permission_system_id = "ps-123456789"
+  role_id             = "arl-abcdef123456"
 }
 
 output "role_permissions" {
@@ -25,16 +25,18 @@ output "role_permissions" {
 
 The following arguments are supported:
 
-* `permission_system_id` - (Required) The ID of the permission system containing the role.
-* `role_id` - (Required) The ID of the role to look up.
+* `permission_system_id` - (Required) The ID of the permission system containing the role. Must start with `ps-` followed by alphanumeric characters or hyphens.
+* `role_id` - (Required) The ID of the role to look up. Must start with `arl-` followed by alphanumeric characters or hyphens.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - A unique identifier for this role.
-* `name` - The name of the role.
-* `description` - The description of the role.
-* `permissions` - A map of permissions granted by this role.
-* `created_at` - The timestamp when the role was created.
-* `updated_at` - The timestamp when the role was last updated. 
+* `name` - The name of the role. Will be between 1 and 50 characters.
+* `description` - The description of the role. Maximum length is 200 characters.
+* `permissions` - A map of permissions granted by this role. Most permissions are boolean and use "true" as the value.
+* `created_at` - The timestamp when the role was created (RFC 3339 format).
+* `creator` - The name of the user that created this role.
+* `updated_at` - The timestamp when the role was last updated (RFC 3339 format).
+* `updater` - The name of the user that last updated this role. 

--- a/docs/data-sources/service_account.md
+++ b/docs/data-sources/service_account.md
@@ -13,8 +13,8 @@ This data source retrieves information about a specific service account in an Au
 
 ```terraform
 data "cloudapi_service_account" "example" {
-  permission_system_id = "sys_123456789"
-  service_account_id   = "sa_abcdef123456"
+  permission_system_id = "ps-123456789"
+  service_account_id   = "sva-abcdef123456"
 }
 
 output "service_account_name" {
@@ -26,15 +26,17 @@ output "service_account_name" {
 
 The following arguments are supported:
 
-* `permission_system_id` - (Required) The ID of the permission system containing the service account.
-* `service_account_id` - (Required) The ID of the service account to look up.
+* `permission_system_id` - (Required) The ID of the permission system containing the service account. Must start with `ps-` followed by alphanumeric characters or hyphens.
+* `service_account_id` - (Required) The ID of the service account to look up. Must start with `sva-` followed by alphanumeric characters or hyphens.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - A composite ID uniquely identifying this service account.
-* `name` - The name of the service account.
-* `description` - The description of the service account.
-* `created_at` - The timestamp when the service account was created.
-* `updated_at` - The timestamp when the service account was last updated. 
+* `name` - The name of the service account. Will be between 1 and 50 characters.
+* `description` - The description of the service account. Maximum length is 200 characters.
+* `created_at` - The timestamp when the service account was created (RFC 3339 format).
+* `creator` - The name of the user that created this service account.
+* `updated_at` - The timestamp when the service account was last updated (RFC 3339 format).
+* `updater` - The name of the user that last updated this service account. 

--- a/docs/data-sources/token.md
+++ b/docs/data-sources/token.md
@@ -12,9 +12,9 @@ This data source retrieves information about a specific token belonging to a ser
 
 ```terraform
 data "cloudapi_token" "example" {
-  permission_system_id = "sys_123456789"
-  service_account_id   = "sva_abcdef123456"
-  token_id             = "tok_987654321"
+  permission_system_id = "ps-123456789"
+  service_account_id   = "sva-abcdef123456"
+  token_id            = "atk-987654321"
 }
 
 output "token_name" {
@@ -26,18 +26,20 @@ output "token_name" {
 
 The following arguments are supported:
 
-* `permission_system_id` - (Required) The ID of the permission system the token belongs to.
-* `service_account_id` - (Required) The ID of the service account this token belongs to.
-* `token_id` - (Required) The ID of the token to look up.
+* `permission_system_id` - (Required) The ID of the permission system the token belongs to. Must start with `ps-` followed by alphanumeric characters or hyphens.
+* `service_account_id` - (Required) The ID of the service account this token belongs to. Must start with `sva-` followed by alphanumeric characters or hyphens.
+* `token_id` - (Required) The ID of the token to look up. Must start with `atk-` followed by alphanumeric characters or hyphens.
 
 ## Attribute Reference
 
 The following attributes are exported:
 
 * `id` - A unique identifier for this token.
-* `name` - The name of the token.
-* `description` - The description of the token.
-* `created_at` - The timestamp when the token was created.
-* `updated_at` - The timestamp when the token was last updated.
+* `name` - The name of the token. Will be between 1 and 50 characters.
+* `description` - The description of the token. Maximum length is 200 characters.
+* `created_at` - The timestamp when the token was created (RFC 3339 format).
+* `creator` - The name of the user that created this token.
+* `updated_at` - The timestamp when the token was last updated (RFC 3339 format).
+* `updater` - The name of the user that last updated this token.
 
 ~> **Note:** For security reasons, token secrets are not available through this data source. 

--- a/docs/data-sources/token.md
+++ b/docs/data-sources/token.md
@@ -13,7 +13,7 @@ This data source retrieves information about a specific token belonging to a ser
 ```terraform
 data "cloudapi_token" "example" {
   permission_system_id = "ps-123456789"
-  service_account_id   = "sva-abcdef123456"
+  service_account_id   = "asa-abcdef123456"
   token_id            = "atk-987654321"
 }
 
@@ -27,7 +27,7 @@ output "token_name" {
 The following arguments are supported:
 
 * `permission_system_id` - (Required) The ID of the permission system the token belongs to. Must start with `ps-` followed by alphanumeric characters or hyphens.
-* `service_account_id` - (Required) The ID of the service account this token belongs to. Must start with `sva-` followed by alphanumeric characters or hyphens.
+* `service_account_id` - (Required) The ID of the service account this token belongs to. Must start with `asa-` followed by alphanumeric characters or hyphens.
 * `token_id` - (Required) The ID of the token to look up. Must start with `atk-` followed by alphanumeric characters or hyphens.
 
 ## Attribute Reference
@@ -37,6 +37,7 @@ The following attributes are exported:
 * `id` - A unique identifier for this token.
 * `name` - The name of the token. Will be between 1 and 50 characters.
 * `description` - The description of the token. Maximum length is 200 characters.
+* `hash` - The SHA256 hash of the secret part of the token, without the prefix.
 * `created_at` - The timestamp when the token was created (RFC 3339 format).
 * `creator` - The name of the user that created this token.
 * `updated_at` - The timestamp when the token was last updated (RFC 3339 format).

--- a/docs/data-sources/tokens.md
+++ b/docs/data-sources/tokens.md
@@ -13,8 +13,8 @@ This data source retrieves a list of all tokens belonging to a service account i
 
 ```terraform
 data "cloudapi_tokens" "all" {
-  permission_system_id = "sys_123456789"
-  service_account_id   = "sa_abcdef123456"
+  permission_system_id = "ps-123456789"
+  service_account_id   = "asa-abcdef123456"
 }
 
 output "token_names" {
@@ -26,8 +26,8 @@ output "token_names" {
 
 The following arguments are supported:
 
-* `permission_system_id` - (Required) The ID of the permission system containing the tokens.
-* `service_account_id` - (Required) The ID of the service account to list tokens for.
+* `permission_system_id` - (Required) The ID of the permission system containing the tokens. Must start with `ps-` followed by alphanumeric characters or hyphens.
+* `service_account_id` - (Required) The ID of the service account to list tokens for. Must start with `asa-` followed by alphanumeric characters or hyphens.
 
 ## Attributes Reference
 
@@ -35,11 +35,14 @@ The following attributes are exported:
 
 * `id` - A unique identifier for this data source in the Terraform state.
 * `tokens` - A list of tokens. Each token contains the following attributes:
-  * `id` - The ID of the token.
-  * `name` - The name of the token.
-  * `description` - The description of the token.
-  * `created_at` - The timestamp when the token was created.
-  * `creator` - The identifier of the creator of the token.
+  * `id` - The ID of the token. Will start with `atk-` followed by alphanumeric characters or hyphens.
+  * `name` - The name of the token. Will be between 1 and 50 characters.
+  * `description` - The description of the token. Maximum length is 200 characters.
+  * `hash` - The SHA256 hash of the secret part of the token, without the prefix.
+  * `created_at` - The timestamp when the token was created (RFC 3339 format).
+  * `creator` - The name of the user that created this token.
+  * `updated_at` - The timestamp when the token was last updated (RFC 3339 format).
+  * `updater` - The name of the user that last updated this token.
 * `tokens_count` - The total number of tokens found.
 
 ~> **Note:** For security reasons, token secrets are not available through this data source.  

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -8,15 +8,13 @@ description: |-
 
 This resource allows you to create and manage access control policies that connect service accounts with roles. Policies are the mechanism for controlling what actions service accounts can perform on your AuthZed permission systems.
 
--> **Note:** The AuthZed API does not support updating policies. Any change to policy attributes will force the creation of a new policy and the deletion of the old one.
-
 ## Example Usage
 
 ```terraform
 resource "cloudapi_policy" "reader_policy" {
   name                 = "reader-policy"
   description          = "Grant read-only access"
-  permission_system_id = "sys_123456789"
+  permission_system_id = "ps-123456789"
   principal_id         = cloudapi_service_account.api_service.id
   role_ids             = [cloudapi_role.reader.id]
 }
@@ -24,24 +22,26 @@ resource "cloudapi_policy" "reader_policy" {
 
 ## Argument Reference
 
-* `name` - (Required) A name for the policy.
-* `description` - (Optional) A description explaining the policy's purpose.
-* `permission_system_id` - (Required) The ID of the permission system this policy applies to.
+* `name` - (Required) A name for the policy. Must be between 1 and 50 characters.
+* `description` - (Optional) A description explaining the policy's purpose. Maximum length is 200 characters.
+* `permission_system_id` - (Required) The ID of the permission system this policy applies to. Must start with `ps-` followed by alphanumeric characters or hyphens.
 * `principal_id` - (Required) The ID of the service account receiving these permissions.
-* `role_ids` - (Required) A list of role IDs to assign to the service account.
+* `role_ids` - (Required) A list of role IDs to assign to the service account. Currently limited to exactly one role ID.
 
 ## Attribute Reference
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `id` - The unique identifier for the policy.
-* `created_at` - The timestamp when the policy was created.
-* `updated_at` - The timestamp when the policy was last updated.
+* `id` - The unique identifier for the policy. Will start with `apc-` followed by alphanumeric characters or hyphens.
+* `created_at` - The timestamp when the policy was created (RFC 3339 format).
+* `creator` - The name of the user that created this policy.
+* `updated_at` - The timestamp when the policy was last updated (RFC 3339 format).
+* `updater` - The name of the user that last updated this policy.
 
 ## Import
 
 Policies can be imported using a composite ID with the format `permission_system_id:policy_id`, for example:
 
 ```bash
-terraform import cloudapi_policy.reader_policy sys_123456789:pol_abcdef123456
+terraform import cloudapi_policy.reader_policy ps-123456789:apc-abcdef123456
 ``` 

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -8,15 +8,13 @@ description: |-
 
 This resource allows you to create, update and delete roles that define sets of permissions for accessing and managing an AuthZed permission system. Roles are used with policies to control what actions service accounts can perform.
 
--> **Note:** The AuthZed API does not support updating roles. Any change to role attributes will force the creation of a new role and the deletion of the old one.
-
 ## Example Usage
 
 ```terraform
 resource "cloudapi_role" "reader" {
   name                 = "reader"
   description          = "Role for read-only operations"
-  permission_system_id = "sys_123456789"
+  permission_system_id = "ps-123456789"
   permissions = {
     "authzed.v1/ReadSchema"        = "true"
     "authzed.v1/ReadRelationships" = "true"
@@ -27,9 +25,9 @@ resource "cloudapi_role" "reader" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the role.
-* `description` - (Required) A description of the role's purpose.
-* `permission_system_id` - (Required) The ID of the permission system this role belongs to.
+* `name` - (Required) The name of the role. Must be between 1 and 50 characters.
+* `description` - (Optional) A description of the role's purpose. Maximum length is 200 characters.
+* `permission_system_id` - (Required) The ID of the permission system this role belongs to. Must start with `ps-` followed by alphanumeric characters or hyphens.
 * `permissions` - (Required) A map of permission names to their values. Most permissions are boolean and use "true" as the value. These control what actions can be performed on the permission system.
 
 ## Permission Reference
@@ -42,19 +40,25 @@ Here are common permissions that can be granted:
 * `authzed.v1/WriteRelationships` - Allows creating and updating relationships
 * `authzed.v1/DeleteRelationships` - Allows deleting relationships
 * `authzed.v1/CheckPermission` - Allows checking permissions (performing lookups)
+* `authzed.v1/LookupResources` - Allows looking up resources
+* `authzed.v1/LookupSubjects` - Allows looking up subjects
+* `authzed.v1/ExpandPermissionTree` - Allows expanding permission trees
+* `authzed.v1/Watch` - Allows watching for changes
 
 ## Attribute Reference
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `id` - The ID of the role.
-* `created_at` - The timestamp when the role was created.
-* `updated_at` - The timestamp when the role was last updated.
+* `id` - The unique identifier for the role. Will start with `arl-` followed by alphanumeric characters or hyphens.
+* `created_at` - The timestamp when the role was created (RFC 3339 format).
+* `creator` - The name of the user that created this role.
+* `updated_at` - The timestamp when the role was last updated (RFC 3339 format).
+* `updater` - The name of the user that last updated this role.
 
 ## Import
 
 Roles can be imported using a composite ID with the format `permission_system_id:role_id`, for example:
 
 ```bash
-terraform import cloudapi_role.example sys_123456789:rol_987654321
+terraform import cloudapi_role.example ps-123456789:arl-987654321
 ``` 

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -8,36 +8,36 @@ description: |-
 
 This resource allows you to create, update, and delete service accounts for your AuthZed permission systems. Service accounts provide a secure way for applications and services to authenticate with and access your permission systems.
 
--> **Note:** The AuthZed API does not support updating service accounts. Any change to service account attributes will force the creation of a new service account and the deletion of the old one.
-
 ## Example Usage
 
 ```terraform
 resource "cloudapi_service_account" "api_service" {
   name                 = "api-service"
   description          = "Service account for our API backend"
-  permission_system_id = "sys_123456789"
+  permission_system_id = "ps-123456789"
 }
 ```
 
 ## Argument Reference
 
-* `name` - (Required) A name for the service account.
-* `description` - (Optional) A description explaining the service account's purpose.
-* `permission_system_id` - (Required) The ID of the permission system this service account belongs to.
+* `name` - (Required) A name for the service account. Must be between 1 and 50 characters.
+* `description` - (Optional) A description explaining the service account's purpose. Maximum length is 200 characters.
+* `permission_system_id` - (Required) The ID of the permission system this service account belongs to. Must start with `ps-` followed by alphanumeric characters or hyphens.
 
 ## Attribute Reference
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `id` - The unique identifier for the service account.
-* `created_at` - The timestamp when the service account was created.
-* `updated_at` - The timestamp when the service account was last updated.
+* `id` - The unique identifier for the service account. Will start with `sva-` followed by alphanumeric characters or hyphens.
+* `created_at` - The timestamp when the service account was created (RFC 3339 format).
+* `creator` - The name of the user that created this service account.
+* `updated_at` - The timestamp when the service account was last updated (RFC 3339 format).
+* `updater` - The name of the user that last updated this service account.
 
 ## Import
 
 Service accounts can be imported using a composite ID with the format `permission_system_id:service_account_id`, for example:
 
 ```bash
-terraform import cloudapi_service_account.api_service sys_123456789:sva_abcdef123456
+terraform import cloudapi_service_account.api_service ps-123456789:sva-abcdef123456
 ``` 

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -28,7 +28,7 @@ resource "cloudapi_service_account" "api_service" {
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `id` - The unique identifier for the service account. Will start with `sva-` followed by alphanumeric characters or hyphens.
+* `id` - The unique identifier for the service account. Will start with `asa-` followed by alphanumeric characters or hyphens.
 * `created_at` - The timestamp when the service account was created (RFC 3339 format).
 * `creator` - The name of the user that created this service account.
 * `updated_at` - The timestamp when the service account was last updated (RFC 3339 format).
@@ -39,5 +39,5 @@ In addition to the arguments listed above, the following attributes are exported
 Service accounts can be imported using a composite ID with the format `permission_system_id:service_account_id`, for example:
 
 ```bash
-terraform import cloudapi_service_account.api_service ps-123456789:sva-abcdef123456
+terraform import cloudapi_service_account.api_service ps-123456789:asa-abcdef123456
 ``` 

--- a/docs/resources/token.md
+++ b/docs/resources/token.md
@@ -8,7 +8,7 @@ description: |-
 
 This resource allows you to create and manage API tokens that service accounts use to authenticate with AuthZed. Tokens provide secure, programmatic access to your permission systems.
 
--> **Note:** The AuthZed API does not support updating tokens. Any change to token attributes will force the creation of a new token and the deletion of the old one. Remember that when a token is recreated, a new secret is generated and the old one becomes invalid.
+-> **Note:** The token's secret value is only available when the token is first created and cannot be retrieved later. The token remains valid until it is deleted.
 
 ## Example Usage
 
@@ -16,7 +16,7 @@ This resource allows you to create and manage API tokens that service accounts u
 resource "cloudapi_token" "api_token" {
   name                 = "api-service-token"
   description          = "Token for our API service"
-  permission_system_id = "sys_123456789"
+  permission_system_id = "ps-123456789"
   service_account_id   = cloudapi_service_account.api_service.id
 }
 
@@ -28,9 +28,9 @@ output "token_secret" {
 
 ## Argument Reference
 
-* `name` - (Required) A name for the token.
-* `description` - (Optional) A description explaining the token's purpose.
-* `permission_system_id` - (Required) The ID of the permission system this token belongs to.
+* `name` - (Required) A name for the token. Must be between 1 and 50 characters.
+* `description` - (Optional) A description explaining the token's purpose. Maximum length is 200 characters.
+* `permission_system_id` - (Required) The ID of the permission system this token belongs to. Must start with `ps-` followed by alphanumeric characters or hyphens.
 * `service_account_id` - (Required) The ID of the service account this token is for.
 
 ## Attribute Reference
@@ -39,13 +39,15 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `id` - The unique identifier for the token.
 * `secret` - The actual token value that should be used for authentication. This is only available when the token is first created and cannot be retrieved later.
-* `created_at` - The timestamp when the token was created.
-* `updated_at` - The timestamp when the token was last updated.
+* `created_at` - The timestamp when the token was created (RFC 3339 format).
+* `creator` - The name of the user that created this token.
+* `updated_at` - The timestamp when the token was last updated (RFC 3339 format).
+* `updater` - The name of the user that last updated this token.
 
 ## Import
 
 Tokens can be imported using a composite ID with the format `permission_system_id:service_account_id:token_id`, for example:
 
 ```bash
-terraform import cloudapi_token.api_token sys_123456789:sva_abcdef123456:tok_987654321
+terraform import cloudapi_token.api_token ps-123456789:sva-abcdef123456:tok-987654321
 ``` 

--- a/docs/resources/token.md
+++ b/docs/resources/token.md
@@ -17,7 +17,7 @@ resource "cloudapi_token" "api_token" {
   name                 = "api-service-token"
   description          = "Token for our API service"
   permission_system_id = "ps-123456789"
-  service_account_id   = cloudapi_service_account.api_service.id
+  service_account_id   = "asa-abcdef123456"
 }
 
 output "token_secret" {
@@ -31,14 +31,15 @@ output "token_secret" {
 * `name` - (Required) A name for the token. Must be between 1 and 50 characters.
 * `description` - (Optional) A description explaining the token's purpose. Maximum length is 200 characters.
 * `permission_system_id` - (Required) The ID of the permission system this token belongs to. Must start with `ps-` followed by alphanumeric characters or hyphens.
-* `service_account_id` - (Required) The ID of the service account this token is for.
+* `service_account_id` - (Required) The ID of the service account this token is for. Must start with `asa-` followed by alphanumeric characters or hyphens.
 
 ## Attribute Reference
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `id` - The unique identifier for the token.
+* `id` - The unique identifier for the token. Will start with `atk-` followed by alphanumeric characters or hyphens.
 * `secret` - The actual token value that should be used for authentication. This is only available when the token is first created and cannot be retrieved later.
+* `hash` - The SHA256 hash of the secret part of the token, without the prefix.
 * `created_at` - The timestamp when the token was created (RFC 3339 format).
 * `creator` - The name of the user that created this token.
 * `updated_at` - The timestamp when the token was last updated (RFC 3339 format).
@@ -49,5 +50,5 @@ In addition to the arguments listed above, the following attributes are exported
 Tokens can be imported using a composite ID with the format `permission_system_id:service_account_id:token_id`, for example:
 
 ```bash
-terraform import cloudapi_token.api_token ps-123456789:sva-abcdef123456:tok-987654321
+terraform import cloudapi_token.api_token ps-123456789:asa-abcdef123456:atk-987654321
 ``` 


### PR DESCRIPTION
This PR includes changes to reflect the work done to support Update operations.

It also makes docs and references consistent with Cloud API itself, by updating resource ID formats across all components (permission systems, policies, roles, service accounts, and tokens) to use their updated correct prefixes.

Also: expanded PS docs with version information attributes and clarified policy docs regarding role ID limitations.