### PR TITLE
feat(token):Users can securely retrieve value of SA tokens

### DIFF
--- a/dev.tfrc
+++ b/dev.tfrc
@@ -1,1 +1,0 @@
-provider_installation { dev_overrides { "registry.terraform.io/authzed/cloudapi" = "/Users/veronica/code/authzed/terraform-provider-platform-api" } direct {} }

--- a/docs/resources/token.md
+++ b/docs/resources/token.md
@@ -1,54 +1,115 @@
 ---
-page_title: "Resource: cloudapi_token"
+page_title: "Resource: authzed_token"
 description: |-
   Manages API tokens for service accounts to securely access AuthZed.
 ---
 
-# cloudapi_token
+# authzed_token
 
 This resource allows you to create and manage API tokens that service accounts use to authenticate with AuthZed. Tokens provide secure, programmatic access to your permission systems.
 
--> **Note:** The token's secret value is only available when the token is first created and cannot be retrieved later. The token remains valid until it is deleted.
+~> **Security Warning** Token values are sensitive and grant access to your permission system. They are stored in the Terraform state file. Please ensure your state file is stored securely and encrypted. Consider using remote state with encryption enabled.
+
+!> **One-Time Token Access** The token's plaintext value is only available during initial creation via the `plain_text` attribute. After that, only its hash remains available. Make sure to capture and securely store the token when you first see it!
 
 ## Example Usage
 
-```terraform
-resource "cloudapi_token" "api_token" {
-  name                 = "api-service-token"
-  description          = "Token for our API service"
-  permission_system_id = "ps-123456789"
-  service_account_id   = "asa-abcdef123456"
+```hcl
+# Create a service account
+resource "authzed_service_account" "example" {
+  permission_system_id = "ps-example"
+  name                = "example-sa"
+  description         = "Example service account"
 }
 
-output "token_secret" {
-  value     = cloudapi_token.api_token.secret
-  sensitive = true
+# Create a token for the service account
+resource "authzed_token" "example" {
+  permission_system_id = authzed_service_account.example.permission_system_id
+  service_account_id   = authzed_service_account.example.id
+  name                = "example-token"
+  description         = "Example token"
+}
+
+# Output the token value (only available during creation)
+output "token_plain_text" {
+  value     = authzed_token.example.plain_text
+  sensitive = true    # Keeps the token hidden by default
+}
+
+# Output the token hash for verification
+output "token_hash" {
+  value = authzed_token.example.hash
 }
 ```
+
+To retrieve the token value during creation, you have two options:
+
+```bash
+# Option 1: Set sensitive = false in the output to see it during apply
+# Option 2: Use the output command to retrieve it when needed:
+terraform output -raw token_plain_text
+```
+
+## Recommended Workflow
+
+Most Terraform users follow this pattern to handle Authzed tokens:
+
+1. **Create & capture**  
+   Run `terraform apply` and copy the token from the CLI output. This is the only time `plain_text` is available.
+
+2. **Securely store**  
+   Paste the token into your organization's secret management system (Vault, AWS Secrets Manager, Kubernetes Secrets, etc.) immediately.
+
+3. **Keep it in state**  
+   Allow Terraform to preserve the token (marked sensitive) in its state file—and optionally as an `output`—so other resources or modules can reference it without re-creating the token.
+
+4. **Rotate when needed**  
+   When it's time to rotate, create a new `authzed_token` resource, update your consumers to use the new token, then destroy the old token:
+
+   ```hcl
+   resource "authzed_token" "ci_v2" { ... }
+   # then remove or destroy the old one
+   ```
+
+5. **Clean up**  
+   Once everything is migrated off the old token, remove its Terraform resource (and any associated output) and run `terraform apply` to purge it from state.
+
+This gives you a reliable "one-time" capture of the token in your CLI, plus a safe, state-backed credential for all downstream Terraform-driven workflows.
 
 ## Argument Reference
 
 * `name` - (Required) A name for the token. Must be between 1 and 50 characters.
 * `description` - (Optional) A description explaining the token's purpose. Maximum length is 200 characters.
 * `permission_system_id` - (Required) The ID of the permission system this token belongs to. Must start with `ps-` followed by alphanumeric characters or hyphens.
-* `service_account_id` - (Required) The ID of the service account this token is for. Must start with `asa-` followed by alphanumeric characters or hyphens.
+* `service_account_id` - (Required) The ID of the service account this token is for.
 
 ## Attribute Reference
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `id` - The unique identifier for the token. Will start with `atk-` followed by alphanumeric characters or hyphens.
-* `secret` - The actual token value that should be used for authentication. This is only available when the token is first created and cannot be retrieved later.
-* `hash` - The SHA256 hash of the secret part of the token, without the prefix.
-* `created_at` - The timestamp when the token was created (RFC 3339 format).
-* `creator` - The name of the user that created this token.
-* `updated_at` - The timestamp when the token was last updated (RFC 3339 format).
-* `updater` - The name of the user that last updated this token.
+* `id` - The unique identifier for the token.
+* `plain_text` - The actual token value that should be used for authentication. **This is only available when the token is first created and cannot be retrieved later.**
+* `hash` - The SHA256 hash of the token value, without the prefix.
+* `created_at` - The timestamp when the token was created (RFC 3339 format). May not be specified.
+* `creator` - The name of the user that created this token. May be empty.
+* `etag` - Version identifier used to prevent conflicts from concurrent updates.
+
+## State File Security
+
+The token value is stored in the state file as a sensitive value. To protect sensitive values:
+
+1. Use remote state with encryption (e.g., S3 with encryption, HashiCorp Cloud, etc.)
+2. Restrict access to the state file
+3. Never store state files in version control
+4. Use separate state files for resources containing sensitive values
+5. Consider using [dynamic credentials](https://developer.hashicorp.com/terraform/tutorials/cloud/dynamic-credentials) where possible
 
 ## Import
 
-Tokens can be imported using a composite ID with the format `permission_system_id:service_account_id:token_id`, for example:
+Tokens can be imported using the format `permission_system_id/service_account_id/token_id`. 
 
 ```bash
-terraform import cloudapi_token.api_token ps-123456789:asa-abcdef123456:atk-987654321
-``` 
+terraform import authzed_token.example "ps-example/asa-example/atk-example"
+```
+
+~> **Note:** When importing a token, the `plain_text` value is **not available**—only the hash can be imported. This is because tokens are only returned in plaintext during their initial creation.

--- a/internal/client/factories.go
+++ b/internal/client/factories.go
@@ -60,7 +60,7 @@ func NewPolicyResource(decoded any, etag string) Resource {
 
 // NewTokenResource creates a TokenWithETag Resource
 func NewTokenResource(decoded any, etag string) Resource {
-	token, ok := decoded.(*models.Token)
+	token, ok := decoded.(*models.TokenRequest)
 	if !ok {
 		panic("Invalid type for Token")
 	}

--- a/internal/client/test/resource_interface_test.go
+++ b/internal/client/test/resource_interface_test.go
@@ -46,7 +46,7 @@ func TestResourceInterface(t *testing.T) {
 	// Test TokenWithETag
 	tokenID := "atk-901jkl234mno"
 	tokenETag := "W/\"etag-token\""
-	token := &models.Token{ID: tokenID}
+	token := &models.TokenRequest{ID: tokenID}
 	tokenResource := &client.TokenWithETag{
 		Token: token,
 		ETag:  tokenETag,

--- a/internal/models/token.go
+++ b/internal/models/token.go
@@ -1,0 +1,17 @@
+package models
+
+// TokenRequest represents a service account token
+type TokenRequest struct {
+	ID                  string `json:"id"`
+	Name                string `json:"name"`
+	Description         string `json:"description"`
+	PermissionsSystemID string `json:"permissionsSystemID"`
+	ServiceAccountID    string `json:"serviceAccountID"`
+	CreatedAt           string `json:"createdAt"`
+	Creator             string `json:"creator"`
+	UpdatedAt           string `json:"updatedAt"`
+	Updater             string `json:"updater"`
+	Hash                string `json:"hash"`              // The SHA256 hash of the token
+	Secret              string `json:"secret"`            // The token value from API (used for plain_text)
+	ReturnPlainText     bool   `json:"return_plain_text"` // Request plain text token during creation
+}


### PR DESCRIPTION
this pr allows users see the un-hashed value of newly created Service Account tokens so they can be managed through the Terraform state and added to users' prefer secret management tool.
Also included:
- docs to support this change
- repo cleanup nits