### PR TITLE
fix: remove conflicting hidden manifest file

### DIFF
--- a/.terraform-registry-manifest.json
+++ b/.terraform-registry-manifest.json
@@ -1,6 +1,0 @@
-{
-  "version": 1,
-  "metadata": {
-    "protocol_versions": ["5.0"]
-  }
-} 


### PR DESCRIPTION
this pr removes the additional hidden manifest file that was still present from the Speakeasy original setup, aiming to resolve a registry conflict.