### PR TITLE
fix:handle async delete operations (HTTP 202)

### DIFF
--- a/internal/client/constants.go
+++ b/internal/client/constants.go
@@ -7,4 +7,8 @@ const (
 	DefaultAPIVersion = "25r1"
 	// DefaultTimeout is the default timeout for HTTP requests
 	DefaultTimeout = 30 * time.Second
+	// DefaultDeleteTimeout is the default timeout for waiting for delete operations to complete
+	DefaultDeleteTimeout = 5 * time.Minute
+	// DefaultDeletePollInterval is the default interval between polling attempts during delete operations
+	DefaultDeletePollInterval = 2 * time.Second
 )


### PR DESCRIPTION
The cloud API now returns `202` (Accepted) instead of `204` (No Content) for delete operations that are processed asynchronously. This was causing `terraform destroy` to fail with \"API error (status 202)\" even though the deletes were actually succeeding.

Changes:
- Update DeleteResource() to accept both `204` (sync) and `202` (async) responses
- Add polling logic to wait for async deletes to complete (checks for 404)
- Add timeout constants: 5min timeout, 2sec poll interval
- Maintains backward compatibility with sync deletes (204)

Closes #63 