### PR TITLE
feat: add automatic 409 FGAM configuration conflict handling

### DIFF
--- a/internal/client/cloud_client.go
+++ b/internal/client/cloud_client.go
@@ -150,8 +150,8 @@ func (c *CloudClient) UpdateResource(resource Resource, endpoint string, body an
 		return nil, err
 	}
 
-	// Handle the 412 Precondition Failed error by retrying with the latest ETag
-	if respWithETag.Response.StatusCode == http.StatusPreconditionFailed {
+	// Handle retryable errors (412 Precondition Failed, 409 Conflict) by refreshing ETag and retrying
+	retryWithFreshETag := func(errorContext string) error {
 		// Close the body of the first response
 		if respWithETag.Response.Body != nil {
 			_ = respWithETag.Response.Body.Close()
@@ -160,30 +160,21 @@ func (c *CloudClient) UpdateResource(resource Resource, endpoint string, body an
 		// Get the latest ETag
 		latestETag, err := getLatestETag()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get latest ETag for retry: %w", err)
+			return fmt.Errorf("failed to get latest ETag for retry (%s): %w", errorContext, err)
 		}
 
 		// Retry the update with the latest ETag
 		respWithETag, err = updateWithETag(latestETag)
-		if err != nil {
-			return nil, err
-		}
+		return err
 	}
 
-	if respWithETag.Response.StatusCode == http.StatusConflict {
-		// Close the body of the first response
-		if respWithETag.Response.Body != nil {
-			_ = respWithETag.Response.Body.Close()
+	switch respWithETag.Response.StatusCode {
+	case http.StatusPreconditionFailed:
+		if err := retryWithFreshETag("precondition failed"); err != nil {
+			return nil, err
 		}
-
-		latestETag, err := getLatestETag()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get latest ETag after FGAM configuration change: %w", err)
-		}
-
-		// Retry the update with the fresh ETag
-		respWithETag, err = updateWithETag(latestETag)
-		if err != nil {
+	case http.StatusConflict:
+		if err := retryWithFreshETag("FGAM configuration change"); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // HTTPResponder interface for any type that can provide an HTTP response
@@ -36,9 +37,21 @@ type APIError struct {
 
 func (e *APIError) Error() string {
 	if e.Message != "" {
+		// Check if this is a FGAM configuration conflict and provide helpful context
+		if e.StatusCode == 409 && containsFGAMConfigConflict(e.Message) {
+			return fmt.Sprintf("API error (status %d): %s\n\nThis error occurs when the Fine-Grained Access Management (FGAM) configuration for the permission system has been modified by another process. The Terraform provider will automatically retry this operation.", e.StatusCode, e.Message)
+		}
 		return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Message)
 	}
 	return fmt.Sprintf("API error (status %d)", e.StatusCode)
+}
+
+// containsFGAMConfigConflict checks if the error message indicates a FGAM configuration conflict
+func containsFGAMConfigConflict(message string) bool {
+	lowerMessage := strings.ToLower(message)
+
+	return strings.Contains(lowerMessage, "restricted api access configuration") &&
+		strings.Contains(lowerMessage, "has changed")
 }
 
 // NewAPIError creates a new APIError from an HTTPResponder

--- a/internal/client/policy.go
+++ b/internal/client/policy.go
@@ -97,20 +97,95 @@ func (c *CloudClient) CreatePolicy(policy *models.Policy) (*PolicyWithETag, erro
 func (c *CloudClient) UpdatePolicy(policy *models.Policy, etag string) (*PolicyWithETag, error) {
 	path := fmt.Sprintf("/ps/%s/access/policies/%s", policy.PermissionsSystemID, policy.ID)
 
-	// Create a direct PUT request without using UpdateResource
-	req, err := c.NewRequest(http.MethodPut, path, policy)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	// Define a function to get the latest ETag
+	getLatestETag := func() (string, error) {
+		getReq, err := c.NewRequest(http.MethodGet, path, nil)
+		if err != nil {
+			return "", fmt.Errorf("failed to create GET request: %w", err)
+		}
+
+		getResp, err := c.Do(getReq)
+		if err != nil {
+			return "", fmt.Errorf("failed to send GET request: %w", err)
+		}
+		defer func() {
+			if getResp.Response.Body != nil {
+				_ = getResp.Response.Body.Close()
+			}
+		}()
+
+		if getResp.Response.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("failed to get latest ETag, status: %d", getResp.Response.StatusCode)
+		}
+
+		// Extract ETag from response header
+		latestETag := getResp.ETag
+		return latestETag, nil
 	}
 
-	// Only set If-Match header if we have a non-empty ETag
-	if etag != "" {
-		req.Header.Set("If-Match", etag)
+	// Try update with provided ETag
+	updateWithETag := func(currentETag string) (*ResponseWithETag, error) {
+		req, err := c.NewRequest(http.MethodPut, path, policy)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		// Only set If-Match header if we have a non-empty ETag
+		if currentETag != "" {
+			req.Header.Set("If-Match", currentETag)
+		}
+
+		respWithETag, err := c.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to send request: %w", err)
+		}
+
+		return respWithETag, nil
 	}
 
-	respWithETag, err := c.Do(req)
+	// First attempt with the provided ETag
+	respWithETag, err := updateWithETag(etag)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
+		return nil, err
+	}
+
+	// Handle the 412 Precondition Failed error by retrying with the latest ETag
+	if respWithETag.Response.StatusCode == http.StatusPreconditionFailed {
+		// Close the body of the first response
+		if respWithETag.Response.Body != nil {
+			_ = respWithETag.Response.Body.Close()
+		}
+
+		// Get the latest ETag
+		latestETag, err := getLatestETag()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get latest ETag for retry: %w", err)
+		}
+
+		// Retry the update with the latest ETag
+		respWithETag, err = updateWithETag(latestETag)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Handle 409 Conflict error, FGAM config changes, by retrying with fresh ETag
+	if respWithETag.Response.StatusCode == http.StatusConflict {
+		if respWithETag.Response.Body != nil {
+			_ = respWithETag.Response.Body.Close()
+		}
+
+		// Get the latest ETag after FGAM configuration change
+		latestETag, err := getLatestETag()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get latest ETag after FGAM configuration change: %w", err)
+		}
+
+		// Retry the update with the fresh ETag
+		respWithETag, err = updateWithETag(latestETag)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Keep the response body for potential error reporting
@@ -127,53 +202,54 @@ func (c *CloudClient) UpdatePolicy(policy *models.Policy, etag string) (*PolicyW
 		}
 	}()
 
-	if respWithETag.Response.StatusCode != http.StatusOK {
-		// If it's a 404 error, attempt to recreate the resource
-		if respWithETag.Response.StatusCode == http.StatusNotFound {
-			// Recreate the policy using POST to the base endpoint
-			createPath := fmt.Sprintf("/ps/%s/access/policies", policy.PermissionsSystemID)
-			originalID := policy.ID
+	// Handle 404 Not Found
+	if respWithETag.Response.StatusCode == http.StatusNotFound {
+		// Recreate the policy using POST to the base endpoint
+		createPath := fmt.Sprintf("/ps/%s/access/policies", policy.PermissionsSystemID)
+		originalID := policy.ID
 
-			createReq, err := c.NewRequest(http.MethodPost, createPath, policy)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create request for recreation: %w", err)
-			}
-
-			createResp, err := c.Do(createReq)
-			if err != nil {
-				return nil, fmt.Errorf("failed to send create request for recreation: %w", err)
-			}
-
-			defer func() {
-				if createResp.Response.Body != nil {
-					_ = createResp.Response.Body.Close()
-				}
-			}()
-
-			if createResp.Response.StatusCode != http.StatusCreated {
-				return nil, NewAPIError(createResp)
-			}
-
-			// Decode the created policy
-			var createdPolicy models.Policy
-			if err := json.NewDecoder(createResp.Response.Body).Decode(&createdPolicy); err != nil {
-				return nil, fmt.Errorf("failed to decode recreated policy: %w", err)
-			}
-
-			// Create the result with the original ID to maintain consistency
-			result := &PolicyWithETag{
-				Policy: &createdPolicy,
-				ETag:   createResp.ETag,
-			}
-
-			// Force the right ID to maintain Terraform state consistency
-			if result.Policy.ID != originalID {
-				result.Policy.ID = originalID
-			}
-
-			return result, nil
+		createReq, err := c.NewRequest(http.MethodPost, createPath, policy)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request for recreation: %w", err)
 		}
 
+		createResp, err := c.Do(createReq)
+		if err != nil {
+			return nil, fmt.Errorf("failed to send create request for recreation: %w", err)
+		}
+
+		defer func() {
+			if createResp.Response.Body != nil {
+				_ = createResp.Response.Body.Close()
+			}
+		}()
+
+		if createResp.Response.StatusCode != http.StatusCreated {
+			return nil, NewAPIError(createResp)
+		}
+
+		// Decode the created policy
+		var createdPolicy models.Policy
+		if err := json.NewDecoder(createResp.Response.Body).Decode(&createdPolicy); err != nil {
+			return nil, fmt.Errorf("failed to decode recreated policy: %w", err)
+		}
+
+		// Create the result with the original ID to maintain consistency
+		result := &PolicyWithETag{
+			Policy: &createdPolicy,
+			ETag:   createResp.ETag,
+		}
+
+		// Force the right ID to maintain Terraform state consistency
+		if result.Policy.ID != originalID {
+			result.Policy.ID = originalID
+		}
+
+		return result, nil
+	}
+
+	// Handle other error status codes
+	if respWithETag.Response.StatusCode != http.StatusOK {
 		return nil, NewAPIError(respWithETag)
 	}
 

--- a/internal/client/policy.go
+++ b/internal/client/policy.go
@@ -149,8 +149,8 @@ func (c *CloudClient) UpdatePolicy(policy *models.Policy, etag string) (*PolicyW
 		return nil, err
 	}
 
-	// Handle the 412 Precondition Failed error by retrying with the latest ETag
-	if respWithETag.Response.StatusCode == http.StatusPreconditionFailed {
+	// Handle retryable errors (412 Precondition Failed, 409 Conflict) by refreshing ETag and retrying
+	retryWithFreshETag := func(errorContext string) error {
 		// Close the body of the first response
 		if respWithETag.Response.Body != nil {
 			_ = respWithETag.Response.Body.Close()
@@ -159,31 +159,21 @@ func (c *CloudClient) UpdatePolicy(policy *models.Policy, etag string) (*PolicyW
 		// Get the latest ETag
 		latestETag, err := getLatestETag()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get latest ETag for retry: %w", err)
+			return fmt.Errorf("failed to get latest ETag for retry (%s): %w", errorContext, err)
 		}
 
 		// Retry the update with the latest ETag
 		respWithETag, err = updateWithETag(latestETag)
-		if err != nil {
-			return nil, err
-		}
+		return err
 	}
 
-	// Handle 409 Conflict error, FGAM config changes, by retrying with fresh ETag
-	if respWithETag.Response.StatusCode == http.StatusConflict {
-		if respWithETag.Response.Body != nil {
-			_ = respWithETag.Response.Body.Close()
+	switch respWithETag.Response.StatusCode {
+	case http.StatusPreconditionFailed:
+		if err := retryWithFreshETag("precondition failed"); err != nil {
+			return nil, err
 		}
-
-		// Get the latest ETag after FGAM configuration change
-		latestETag, err := getLatestETag()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get latest ETag after FGAM configuration change: %w", err)
-		}
-
-		// Retry the update with the fresh ETag
-		respWithETag, err = updateWithETag(latestETag)
-		if err != nil {
+	case http.StatusConflict:
+		if err := retryWithFreshETag("FGAM configuration change"); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/client/role.go
+++ b/internal/client/role.go
@@ -106,20 +106,94 @@ func (c *CloudClient) CreateRole(role *models.Role) (*RoleWithETag, error) {
 func (c *CloudClient) UpdateRole(role *models.Role, etag string) (*RoleWithETag, error) {
 	path := fmt.Sprintf("/ps/%s/access/roles/%s", role.PermissionsSystemID, role.ID)
 
-	// Create a direct PUT request without using UpdateResource
-	req, err := c.NewRequest(http.MethodPut, path, role)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	getLatestETag := func() (string, error) {
+		getReq, err := c.NewRequest(http.MethodGet, path, nil)
+		if err != nil {
+			return "", fmt.Errorf("failed to create GET request: %w", err)
+		}
+
+		getResp, err := c.Do(getReq)
+		if err != nil {
+			return "", fmt.Errorf("failed to send GET request: %w", err)
+		}
+		defer func() {
+			if getResp.Response.Body != nil {
+				_ = getResp.Response.Body.Close()
+			}
+		}()
+
+		if getResp.Response.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("failed to get latest ETag, status: %d", getResp.Response.StatusCode)
+		}
+
+		// Extract ETag from response header
+		latestETag := getResp.ETag
+		return latestETag, nil
 	}
 
-	// Only set If-Match header if we have a non-empty ETag
-	if etag != "" {
-		req.Header.Set("If-Match", etag)
+	updateWithETag := func(currentETag string) (*ResponseWithETag, error) {
+		req, err := c.NewRequest(http.MethodPut, path, role)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		// Only set If-Match header if we have a non-empty ETag
+		if currentETag != "" {
+			req.Header.Set("If-Match", currentETag)
+		}
+
+		respWithETag, err := c.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to send request: %w", err)
+		}
+
+		return respWithETag, nil
 	}
 
-	respWithETag, err := c.Do(req)
+	// First attempt with the provided ETag
+	respWithETag, err := updateWithETag(etag)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
+		return nil, err
+	}
+
+	// Handle the 412 Precondition Failed error by retrying with the latest ETag
+	if respWithETag.Response.StatusCode == http.StatusPreconditionFailed {
+		// Close the body of the first response
+		if respWithETag.Response.Body != nil {
+			_ = respWithETag.Response.Body.Close()
+		}
+
+		// Get the latest ETag
+		latestETag, err := getLatestETag()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get latest ETag for retry: %w", err)
+		}
+
+		// Retry the update with the latest ETag
+		respWithETag, err = updateWithETag(latestETag)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Handle 409 Conflict error (FGAM configuration changes) by retrying with fresh ETag
+	if respWithETag.Response.StatusCode == http.StatusConflict {
+		// Close the body of the first response
+		if respWithETag.Response.Body != nil {
+			_ = respWithETag.Response.Body.Close()
+		}
+
+		// Get the latest ETag after FGAM configuration change
+		latestETag, err := getLatestETag()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get latest ETag after FGAM configuration change: %w", err)
+		}
+
+		// Retry the update with the fresh ETag
+		respWithETag, err = updateWithETag(latestETag)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Keep the response body for potential error reporting
@@ -136,53 +210,54 @@ func (c *CloudClient) UpdateRole(role *models.Role, etag string) (*RoleWithETag,
 		}
 	}()
 
-	if respWithETag.Response.StatusCode != http.StatusOK {
-		// If it's a 404 error, attempt to recreate the resource
-		if respWithETag.Response.StatusCode == http.StatusNotFound {
-			// Recreate the role using POST to the base endpoint
-			createPath := fmt.Sprintf("/ps/%s/access/roles", role.PermissionsSystemID)
-			originalID := role.ID
+	// Handle 404 Not Found
+	if respWithETag.Response.StatusCode == http.StatusNotFound {
+		// Recreate the role using POST to the base endpoint
+		createPath := fmt.Sprintf("/ps/%s/access/roles", role.PermissionsSystemID)
+		originalID := role.ID
 
-			createReq, err := c.NewRequest(http.MethodPost, createPath, role)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create request for recreation: %w", err)
-			}
-
-			createResp, err := c.Do(createReq)
-			if err != nil {
-				return nil, fmt.Errorf("failed to send create request for recreation: %w", err)
-			}
-
-			defer func() {
-				if createResp.Response.Body != nil {
-					_ = createResp.Response.Body.Close()
-				}
-			}()
-
-			if createResp.Response.StatusCode != http.StatusCreated {
-				return nil, NewAPIError(createResp)
-			}
-
-			// Decode the created role
-			var createdRole models.Role
-			if err := json.NewDecoder(createResp.Response.Body).Decode(&createdRole); err != nil {
-				return nil, fmt.Errorf("failed to decode recreated role: %w", err)
-			}
-
-			// Create the result with the original ID to maintain consistency
-			result := &RoleWithETag{
-				Role: &createdRole,
-				ETag: createResp.ETag,
-			}
-
-			// Force the right ID to maintain Terraform state consistency
-			if result.Role.ID != originalID {
-				result.Role.ID = originalID
-			}
-
-			return result, nil
+		createReq, err := c.NewRequest(http.MethodPost, createPath, role)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request for recreation: %w", err)
 		}
 
+		createResp, err := c.Do(createReq)
+		if err != nil {
+			return nil, fmt.Errorf("failed to send create request for recreation: %w", err)
+		}
+
+		defer func() {
+			if createResp.Response.Body != nil {
+				_ = createResp.Response.Body.Close()
+			}
+		}()
+
+		if createResp.Response.StatusCode != http.StatusCreated {
+			return nil, NewAPIError(createResp)
+		}
+
+		// Decode the created role
+		var createdRole models.Role
+		if err := json.NewDecoder(createResp.Response.Body).Decode(&createdRole); err != nil {
+			return nil, fmt.Errorf("failed to decode recreated role: %w", err)
+		}
+
+		// Create the result with the original ID to maintain consistency
+		result := &RoleWithETag{
+			Role: &createdRole,
+			ETag: createResp.ETag,
+		}
+
+		// Force the right ID to maintain Terraform state consistency
+		if result.Role.ID != originalID {
+			result.Role.ID = originalID
+		}
+
+		return result, nil
+	}
+
+	// Handle other error status codes
+	if respWithETag.Response.StatusCode != http.StatusOK {
 		return nil, NewAPIError(respWithETag)
 	}
 

--- a/internal/client/role.go
+++ b/internal/client/role.go
@@ -156,8 +156,8 @@ func (c *CloudClient) UpdateRole(role *models.Role, etag string) (*RoleWithETag,
 		return nil, err
 	}
 
-	// Handle the 412 Precondition Failed error by retrying with the latest ETag
-	if respWithETag.Response.StatusCode == http.StatusPreconditionFailed {
+	// Handle retryable errors (412 Precondition Failed, 409 Conflict) by refreshing ETag and retrying
+	retryWithFreshETag := func(errorContext string) error {
 		// Close the body of the first response
 		if respWithETag.Response.Body != nil {
 			_ = respWithETag.Response.Body.Close()
@@ -166,32 +166,21 @@ func (c *CloudClient) UpdateRole(role *models.Role, etag string) (*RoleWithETag,
 		// Get the latest ETag
 		latestETag, err := getLatestETag()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get latest ETag for retry: %w", err)
+			return fmt.Errorf("failed to get latest ETag for retry (%s): %w", errorContext, err)
 		}
 
 		// Retry the update with the latest ETag
 		respWithETag, err = updateWithETag(latestETag)
-		if err != nil {
-			return nil, err
-		}
+		return err
 	}
 
-	// Handle 409 Conflict error (FGAM configuration changes) by retrying with fresh ETag
-	if respWithETag.Response.StatusCode == http.StatusConflict {
-		// Close the body of the first response
-		if respWithETag.Response.Body != nil {
-			_ = respWithETag.Response.Body.Close()
+	switch respWithETag.Response.StatusCode {
+	case http.StatusPreconditionFailed:
+		if err := retryWithFreshETag("precondition failed"); err != nil {
+			return nil, err
 		}
-
-		// Get the latest ETag after FGAM configuration change
-		latestETag, err := getLatestETag()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get latest ETag after FGAM configuration change: %w", err)
-		}
-
-		// Retry the update with the fresh ETag
-		respWithETag, err = updateWithETag(latestETag)
-		if err != nil {
+	case http.StatusConflict:
+		if err := retryWithFreshETag("FGAM configuration change"); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/client/service_account.go
+++ b/internal/client/service_account.go
@@ -172,8 +172,8 @@ func (c *CloudClient) UpdateServiceAccount(serviceAccount *models.ServiceAccount
 		return nil, err
 	}
 
-	// Handle the 412 Precondition Failed error by retrying with the latest ETag
-	if respWithETag.Response.StatusCode == http.StatusPreconditionFailed {
+	// Handle retryable errors (412 Precondition Failed, 409 Conflict) by refreshing ETag and retrying
+	retryWithFreshETag := func(errorContext string) error {
 		// Close the body of the first response
 		if respWithETag.Response.Body != nil {
 			_ = respWithETag.Response.Body.Close()
@@ -182,32 +182,21 @@ func (c *CloudClient) UpdateServiceAccount(serviceAccount *models.ServiceAccount
 		// Get the latest ETag
 		latestETag, err := getLatestETag()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get latest ETag for retry: %w", err)
+			return fmt.Errorf("failed to get latest ETag for retry (%s): %w", errorContext, err)
 		}
 
 		// Retry the update with the latest ETag
 		respWithETag, err = updateWithETag(latestETag)
-		if err != nil {
-			return nil, err
-		}
+		return err
 	}
 
-	// Handle 409 Conflict error, FGAM config changes, by retrying with fresh ETag
-	if respWithETag.Response.StatusCode == http.StatusConflict {
-		// Close the body of the first response
-		if respWithETag.Response.Body != nil {
-			_ = respWithETag.Response.Body.Close()
+	switch respWithETag.Response.StatusCode {
+	case http.StatusPreconditionFailed:
+		if err := retryWithFreshETag("precondition failed"); err != nil {
+			return nil, err
 		}
-
-		// Get the latest ETag after FGAM config change
-		latestETag, err := getLatestETag()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get latest ETag after FGAM configuration change: %w", err)
-		}
-
-		// Retry the update with the fresh ETag
-		respWithETag, err = updateWithETag(latestETag)
-		if err != nil {
+	case http.StatusConflict:
+		if err := retryWithFreshETag("FGAM configuration change"); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/client/test/fgam_error_test.go
+++ b/internal/client/test/fgam_error_test.go
@@ -1,0 +1,75 @@
+package test
+
+import (
+	"testing"
+
+	"terraform-provider-authzed/internal/client"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFGAMErrorMessages(t *testing.T) {
+	t.Run("DetectsFGAMConfigConflict", func(t *testing.T) {
+		// Test error message that indicates FGAM configuration conflict
+		apiErr := &client.APIError{
+			StatusCode: 409,
+			Message:    "restricted API access configuration for permission system \"ps-test123\" has changed",
+		}
+
+		errorMsg := apiErr.Error()
+
+		// Should contain the helpful context message
+		assert.Contains(t, errorMsg, "Fine-Grained Access Management (FGAM) configuration")
+		assert.Contains(t, errorMsg, "automatically retry")
+		assert.Contains(t, errorMsg, "status 409")
+	})
+
+	t.Run("DoesNotDetectNonFGAMConflict", func(t *testing.T) {
+		// Test error message that is 409 but not FGAM related
+		apiErr := &client.APIError{
+			StatusCode: 409,
+			Message:    "resource conflict: another process is modifying this resource",
+		}
+
+		errorMsg := apiErr.Error()
+
+		// Should NOT contain the FGAM-specific context message
+		assert.NotContains(t, errorMsg, "Fine-Grained Access Management")
+		assert.Contains(t, errorMsg, "status 409")
+		assert.Contains(t, errorMsg, "resource conflict")
+	})
+
+	t.Run("HandlesCaseInsensitiveFGAMDetection", func(t *testing.T) {
+		// Test with different case variations
+		testCases := []string{
+			"Restricted API Access Configuration for permission system \"ps-test\" has changed",
+			"RESTRICTED API ACCESS CONFIGURATION for permission system \"ps-test\" HAS CHANGED",
+			"restricted api access configuration for permission system \"ps-test\" has changed",
+		}
+
+		for _, message := range testCases {
+			apiErr := &client.APIError{
+				StatusCode: 409,
+				Message:    message,
+			}
+
+			errorMsg := apiErr.Error()
+			assert.Contains(t, errorMsg, "Fine-Grained Access Management (FGAM) configuration",
+				"Should detect FGAM conflict in message: %s", message)
+		}
+	})
+
+	t.Run("HandlesNon409Errors", func(t *testing.T) {
+		// Test that non-409 errors don't get FGAM treatment
+		apiErr := &client.APIError{
+			StatusCode: 400,
+			Message:    "restricted API access configuration for permission system \"ps-test\" has changed",
+		}
+
+		errorMsg := apiErr.Error()
+
+		// Should NOT contain the FGAM-specific context message for non-409 errors
+		assert.NotContains(t, errorMsg, "Fine-Grained Access Management")
+		assert.Contains(t, errorMsg, "status 400")
+	})
+}


### PR DESCRIPTION
This PR adds `409 conflict` detection and retry logic for all the resources: service account, role, policy, and token updates.
It also implements automatic e-tag refresh and retry on 409 conflicts across all update methods.

Unit tests were also added to support this feature.

### Testing

I tested this change by executing all the operations (`init`, `apply`, `update`) against real API resources to verify that our `409 conflict` detection and automatic retry logic functions correctly. The operations included creating service accounts and tokens, then updating service account metadata to trigger PUT requests that could potentially encounter FGAM configuration conflicts.