### PR TITLE
fix: prevent state drift in immutable fields during updates

### DIFF
--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -243,15 +243,11 @@ func (r *policyResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Update resource data with the response
-	data.ID = types.StringValue(updatedPolicyWithETag.Policy.ID)
-
-	// If the ID is empty, preserve the original ID
-	if data.ID.ValueString() == "" {
-		data.ID = state.ID
-	}
-
-	data.CreatedAt = types.StringValue(updatedPolicyWithETag.Policy.CreatedAt)
-	data.Creator = types.StringValue(updatedPolicyWithETag.Policy.Creator)
+	// Preserve immutable fields from state
+	data.ID = state.ID
+	data.CreatedAt = state.CreatedAt
+	data.Creator = state.Creator
+	// Only update fields that can actually change
 	data.ETag = types.StringValue(updatedPolicyWithETag.ETag)
 
 	// Update role IDs in case the order or values changed

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -223,15 +223,11 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Update resource data with the response
-	data.ID = types.StringValue(updatedRoleWithETag.Role.ID)
-
-	// If the ID is empty, preserve the original ID
-	if data.ID.ValueString() == "" {
-		data.ID = state.ID
-	}
-
-	data.CreatedAt = types.StringValue(updatedRoleWithETag.Role.CreatedAt)
-	data.Creator = types.StringValue(updatedRoleWithETag.Role.Creator)
+	// Preserve immutable fields from state
+	data.ID = state.ID
+	data.CreatedAt = state.CreatedAt
+	data.Creator = state.Creator
+	// Only update fields that can actually change
 	data.ETag = types.StringValue(updatedRoleWithETag.ETag)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/token_resource.go
+++ b/internal/provider/token_resource.go
@@ -277,8 +277,10 @@ func (r *TokenResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	// Update resource data with the response
-	plan.CreatedAt = types.StringValue(updatedTokenWithETag.Token.CreatedAt)
-	plan.Creator = types.StringValue(updatedTokenWithETag.Token.Creator)
+	// Preserve immutable fields from state
+	plan.CreatedAt = state.CreatedAt
+	plan.Creator = state.Creator
+	// Only update fields that can actually change
 	plan.ETag = types.StringValue(updatedTokenWithETag.ETag)
 
 	// Preserve the token value and hash from state since they won't be returned in updates


### PR DESCRIPTION
this pr preserves `id`, `created_at`, and `creator` fields from existing state during resource updates instead of overwriting from API responses. These fields are immutable after creation and overwriting them caused false diffs in `terraform plan` output.

Affects: policy, service_account, role, and token resources.