### PR TITLE
fix: remove remaining plan modifiers from policy resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2025-01-08
+
+### Fixed
+- Ensures consistent behavior across all resources and eliminates plan inconsistencies for policy updates
+
+## [0.4.0] - 2025-01-08
+
+### Added
+- Native FGAM (Fine-Grained Access Management) field support for all resources
+- New `updated_at` and `updater` fields for Service Accounts, Roles, Policies, and Tokens
+- Enhanced retry logic with support for 429 (Rate Limit) status codes
+- Improved concurrent operation handling with increased retry limits
+
+### Fixed
+- **CRITICAL**: Resolved "Provider produced inconsistent result after apply" errors caused by etag inconsistencies
+- Fixed etag handling by removing incorrect UseStateForUnknown() plan modifiers from etag fields
+- Ensured etag values always come from API responses for consistent state management
+
 ### Changed
-- Renamed provider from `platform-api` to `cloudapi` for Terraform Registry compliance
-- Updated documentation to reflect new provider name
-- Improved README with more detailed examples
+- Removed provider-side FGAM patches and locking mechanisms in favor of native API support
+- Updated OpenAPI spec integration to use latest API fixes
+
+
+### Removed
+- Provider-side FGAM coordinators and serialization logic (replaced by native API support)
 
 ## [0.1.0] - 2023-08-15
 

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -11,8 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -54,9 +52,6 @@ func (r *policyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"id": schema.StringAttribute{
 				Computed:    true,
 				Description: "Unique identifier for this resource",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
@@ -82,16 +77,10 @@ func (r *policyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"created_at": schema.StringAttribute{
 				Computed:    true,
 				Description: "Timestamp when the policy was created",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"creator": schema.StringAttribute{
 				Computed:    true,
 				Description: "User who created the policy",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"updated_at": schema.StringAttribute{
 				Computed:    true,


### PR DESCRIPTION
After the refactor done on https://github.com/authzed/terraform-provider-authzed/pull/89, now we can also remove UseStateForUnknown() from policy `resource id`, `created_at`, and `creator` fields.

This aligns Policy with the rest of the resources (service account, role, token).
