### PR TITLE
Add authzed_materialize_deployment resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **New resource `authzed_materialize_deployment`** - Create, update, delete, and import AuthZed Materialize deployments for a permission system deployment (uses the internal API version, which has no compatibility guarantees and can change or break at any time)
 - **Concurrency testing suite** - Performance benchmarking (15-75 resources), concurrent creation tests, and eventual consistency validation
 - **DeleteLanes infrastructure** - Conflict resolution system for resource deletion with intelligent retry logic
 - **Per-Permission System serialization lanes (PSLanes)** - Concurrent operations across different permission systems while preventing FGAM conflicts

--- a/docs/resources/materialize_deployment.md
+++ b/docs/resources/materialize_deployment.md
@@ -1,0 +1,117 @@
+---
+page_title: "Resource: authzed_materialize_deployment"
+description: |-
+  Manages AuthZed Materialize deployments for a permission system deployment.
+---
+
+# authzed_materialize_deployment
+
+This resource allows you to create, update, and delete AuthZed Materialize
+deployments. A Materialize deployment continuously materializes the
+permissions you specify from a permission system deployment, serving them
+from a low-latency cache.
+
+~> **Warning:** This resource uses the internal API version. The provider
+sends the required `X-API-Version: internal` header for Materialize
+operations automatically, regardless of the `api_version` configured on the
+provider. The internal API comes with no compatibility guarantees: it can
+change or break at any time without notice, and this resource may stop
+working until a provider update restores compatibility. Promotion of these
+endpoints to the public API is planned to align with the Materialize GA
+release.
+
+## Example Usage
+
+```terraform
+resource "authzed_materialize_deployment" "example" {
+  name                  = "my-materialize"
+  permission_system_id  = "ps-123456789"
+  deployment_id         = "dp-123456789"
+  server_template_id    = "mtsc-4-vcpu"
+  snapshot_template_id  = "mtssc-4-vcpu"
+  hydration_template_id = "mthc-4-vcpu"
+
+  watched_permissions = [
+    "document#view@user",
+  ]
+
+  replicas            = 2
+  accelerated_queries = true
+
+  timeouts {
+    create = "45m"
+    update = "45m"
+  }
+}
+```
+
+## Argument Reference
+
+- `name` - (Required) Name of the Materialize deployment. Must follow the
+  RFC-1123 naming convention (lowercase alphanumerics and hyphens, max 50
+  characters). Changing it forces a new deployment.
+- `permission_system_id` - (Required) ID of the permission system to
+  materialize permissions from (`ps-...`). Changing it forces a new
+  deployment.
+- `deployment_id` - (Required) ID of the permission system deployment that
+  provides incremental updates (`dp-...`). Changing it forces a new
+  deployment.
+- `server_template_id` - (Required) ID of the Materialize online hydration
+  server template (e.g. `mtsc-4-vcpu` — see
+  [Available Templates](#available-templates)).
+- `snapshot_template_id` - (Required) ID of the Materialize snapshot
+  template (e.g. `mtssc-4-vcpu` — see
+  [Available Templates](#available-templates)).
+- `hydration_template_id` - (Required) ID of the Materialize offline
+  hydration template (e.g. `mthc-4-vcpu` — see
+  [Available Templates](#available-templates)).
+- `watched_permissions` - (Required) List of permissions to materialize, in
+  the format `resource_type#relation@subject_type[#subject_relation]`
+  (1-100 entries). Updates replace the entire list.
+- `replicas` - (Optional) Number of online hydration server replicas
+  (0-16). Zero temporarily disables the deployment without deleting it.
+  When omitted, the server template default applies and the applied value
+  is read back into state.
+- `accelerated_queries` - (Optional) When `true`, this deployment
+  accelerates the permission system's `CheckPermission`, `LookupResources`,
+  and `LookupSubjects` queries by serving as a hedged, lower-latency cache.
+  When omitted, the value is read back from the deployment status.
+- `timeouts` - (Optional) Operation timeouts. Creating and updating a
+  Materialize deployment waits until the deployment is provisioned and its
+  snapshot job has started — not until it is fully hydrated and serving,
+  which is data-dependent and can take hours. Both default to 30 minutes.
+  Deletion is asynchronous and bounded by the provider-level
+  `delete_timeout`.
+
+## Available Templates
+
+Template IDs follow the pattern `<prefix>-<N>-vcpu`, where `N` is the number
+of vCPUs provisioned per replica of that component. The following sizes are
+available:
+
+| Size (vCPU) | Server (`server_template_id`) | Snapshot (`snapshot_template_id`) | Hydration (`hydration_template_id`) |
+|---|---|---|---|
+| 1  | `mtsc-1-vcpu`  | `mtssc-1-vcpu`  | `mthc-1-vcpu`  |
+| 2  | `mtsc-2-vcpu`  | `mtssc-2-vcpu`  | `mthc-2-vcpu`  |
+| 4  | `mtsc-4-vcpu`  | `mtssc-4-vcpu`  | `mthc-4-vcpu`  |
+| 8  | `mtsc-8-vcpu`  | `mtssc-8-vcpu`  | `mthc-8-vcpu`  |
+| 16 | `mtsc-16-vcpu` | `mtssc-16-vcpu` | `mthc-16-vcpu` |
+| 32 | `mtsc-32-vcpu` | `mtssc-32-vcpu` | `mthc-32-vcpu` |
+
+~> **Note:** The 1 vCPU size is not available on Azure-based environments,
+which start at 2 vCPU. The available set can vary by environment and may
+change over time.
+
+## Attribute Reference
+
+- `id` - Unique identifier of the Materialize deployment (`mc-...`).
+- `url` - Endpoint URL of the Materialize deployment.
+- `created_at` - Timestamp when the Materialize deployment was created.
+
+## Import
+
+Materialize deployments can be imported using their ID:
+
+```shell
+terraform import authzed_materialize_deployment.example mc-123456789
+```

--- a/examples/resources/authzed_materialize_deployment/resource.tf
+++ b/examples/resources/authzed_materialize_deployment/resource.tf
@@ -1,0 +1,20 @@
+resource "authzed_materialize_deployment" "example" {
+  name                  = "my-materialize"
+  permission_system_id  = "ps-123456789"
+  deployment_id         = "dp-123456789"
+  server_template_id    = "mtsc-4-vcpu"
+  snapshot_template_id  = "mtssc-4-vcpu"
+  hydration_template_id = "mthc-4-vcpu"
+
+  watched_permissions = [
+    "document#view@user",
+  ]
+
+  replicas            = 2
+  accelerated_queries = true
+
+  timeouts {
+    create = "45m"
+    update = "45m"
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module terraform-provider-authzed
 go 1.24.2
 
 require (
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/hashicorp/terraform-plugin-framework v1.17.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/catenacyber/perfsprint v0.9.1 h1:5LlTp4RwTooQjJCvGEFV6XksZvWE7wCOUvjD
 github.com/catenacyber/perfsprint v0.9.1/go.mod h1:q//VWC2fWbcdSLEY1R3l8n0zQCDPdE4IjZwyY1HMunM=
 github.com/ccojocar/zxcvbn-go v1.0.4 h1:FWnCIRMXPj43ukfX000kvBZvV6raSxakYr1nzyNrUcc=
 github.com/ccojocar/zxcvbn-go v1.0.4/go.mod h1:3GxGX+rHmueTUMvm5ium7irpyjmm7ikxYFOSJB21Das=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charithe/durationcheck v0.0.10 h1:wgw73BiocdBDQPik+zcEoBG/ob8uyBHf2iyoHGPf5w4=

--- a/internal/client/cloud_client.go
+++ b/internal/client/cloud_client.go
@@ -123,6 +123,13 @@ var _ HTTPResponder = (*ResponseWithETag)(nil)
 // RequestOption allows setting optional parameters for requests
 type RequestOption func(*http.Request)
 
+// WithAPIVersion overrides the X-API-Version header for a single request
+func WithAPIVersion(version string) RequestOption {
+	return func(req *http.Request) {
+		req.Header.Set("X-API-Version", version)
+	}
+}
+
 // IdempotentRecoveryConfig configures idempotent recovery for create operations
 type IdempotentRecoveryConfig struct {
 	ResourceType string
@@ -172,8 +179,8 @@ func (c *CloudClient) Do(req *http.Request) (*ResponseWithETag, error) {
 }
 
 // DeleteResource deletes a resource
-func (c *CloudClient) DeleteResource(endpoint string) error {
-	req, err := c.NewRequest(http.MethodDelete, endpoint, nil)
+func (c *CloudClient) DeleteResource(endpoint string, options ...RequestOption) error {
+	req, err := c.NewRequest(http.MethodDelete, endpoint, nil, options...)
 	if err != nil {
 		return err
 	}
@@ -193,7 +200,7 @@ func (c *CloudClient) DeleteResource(endpoint string) error {
 		if os.Getenv("AUTHZED_DELETE_CONFIRM_ON_204") == "1" {
 			confirmCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			if req2, err := c.NewRequest(http.MethodGet, endpoint, nil); err == nil {
+			if req2, err := c.NewRequest(http.MethodGet, endpoint, nil, options...); err == nil {
 				req2 = req2.WithContext(confirmCtx)
 				if resp2, err2 := c.Do(req2); err2 == nil {
 					_ = resp2.Response.Body.Close()
@@ -208,7 +215,7 @@ func (c *CloudClient) DeleteResource(endpoint string) error {
 	}
 	// 202 Accepted: async delete, poll for completion
 	if status == http.StatusAccepted {
-		return c.waitForDeletion(endpoint)
+		return c.waitForDeletion(endpoint, options...)
 	}
 
 	// Other statuses are errors
@@ -216,7 +223,7 @@ func (c *CloudClient) DeleteResource(endpoint string) error {
 }
 
 // waitForDeletion polls the resource endpoint until it returns 404/410 (deleted)
-func (c *CloudClient) waitForDeletion(endpoint string) error {
+func (c *CloudClient) waitForDeletion(endpoint string, options ...RequestOption) error {
 	// Overall timeout
 	ctx, cancel := context.WithTimeout(context.Background(), c.DeleteTimeout)
 	defer cancel()
@@ -233,7 +240,7 @@ func (c *CloudClient) waitForDeletion(endpoint string) error {
 
 		// Short per-probe timeout
 		probeCtx, probeCancel := context.WithTimeout(ctx, 15*time.Second)
-		req, err := c.NewRequest(http.MethodGet, endpoint, nil)
+		req, err := c.NewRequest(http.MethodGet, endpoint, nil, options...)
 		if err != nil {
 			probeCancel()
 			return fmt.Errorf("failed to create request while polling for deletion: %w", err)

--- a/internal/client/constants.go
+++ b/internal/client/constants.go
@@ -17,4 +17,9 @@ const (
 	DefaultBaseRetryDelay = 200 * time.Millisecond
 	DefaultMaxRetryDelay  = 5 * time.Second
 	DefaultMaxJitter      = 500 * time.Millisecond
+
+	// MaterializeAPIVersion is the API version required by the Materialize
+	// endpoints, which only exist in the internal API version. Update this
+	// once the Materialize API is promoted to a public version.
+	MaterializeAPIVersion = "internal"
 )

--- a/internal/client/materialize.go
+++ b/internal/client/materialize.go
@@ -1,0 +1,213 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+
+	"terraform-provider-authzed/internal/models"
+)
+
+// NewPollBackOff returns the exponential backoff used to poll long-running
+// Materialize operations: 250ms initial interval capped at 5s, bounded by
+// the caller's context rather than an elapsed-time limit.
+func NewPollBackOff() *backoff.ExponentialBackOff {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = 250 * time.Millisecond
+	b.MaxInterval = 5 * time.Second
+	b.MaxElapsedTime = 0
+	return b
+}
+
+// doMaterializeRequest sends a request to a Materialize endpoint with the
+// internal API version. Idempotent methods retry on 429/5xx with backoff; a
+// POST is only retried on 429, which guarantees the request was not
+// processed — retrying an ambiguous 5xx could create a duplicate deployment
+// that Terraform would never track. It must never retry 404 (used as a
+// signal by existence polling) or 409/412 (the Materialize API has no ETag
+// semantics).
+func (c *CloudClient) doMaterializeRequest(ctx context.Context, method, path string, body any) (*ResponseWithETag, error) {
+	retryable := func(status int) bool {
+		if status == http.StatusTooManyRequests {
+			return true
+		}
+		return method != http.MethodPost && status >= 500
+	}
+
+	var resp *ResponseWithETag
+	operation := func() error {
+		req, err := c.NewRequest(method, path, body, WithAPIVersion(MaterializeAPIVersion))
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		req = req.WithContext(ctx)
+
+		result, err := c.Do(req)
+		if err != nil {
+			// A network error is ambiguous for a non-idempotent request;
+			// fail fast rather than risk a duplicate.
+			return backoff.Permanent(err)
+		}
+		if retryable(result.Response.StatusCode) {
+			apiErr := NewAPIError(result)
+			_ = result.Response.Body.Close()
+			return apiErr
+		}
+		resp = result
+		return nil
+	}
+
+	b := backoff.WithMaxRetries(NewPollBackOff(), uint64(DefaultMaxRetries))
+	if err := backoff.Retry(operation, backoff.WithContext(b, ctx)); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// CreateMaterializeDeployment creates a Materialize deployment for a
+// permission system deployment
+func (c *CloudClient) CreateMaterializeDeployment(ctx context.Context, createReq *models.CreateMaterializeDeploymentRequest) (*models.CreateMaterializeDeploymentResponse, error) {
+	resp, err := c.doMaterializeRequest(ctx, http.MethodPost, "/materialize", createReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Response.Body.Close()
+	}()
+
+	if resp.Response.StatusCode != http.StatusCreated {
+		return nil, NewAPIError(resp)
+	}
+
+	var created models.CreateMaterializeDeploymentResponse
+	if err := json.NewDecoder(resp.Response.Body).Decode(&created); err != nil {
+		return nil, fmt.Errorf("failed to decode create materialize deployment response: %w", err)
+	}
+	return &created, nil
+}
+
+// GetMaterializeDeployment fetches a Materialize deployment by its mc-... ID
+func (c *CloudClient) GetMaterializeDeployment(ctx context.Context, id string) (*models.MaterializeDeployment, error) {
+	resp, err := c.doMaterializeRequest(ctx, http.MethodGet, fmt.Sprintf("/materialize/%s", id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Response.Body.Close()
+	}()
+
+	if resp.Response.StatusCode != http.StatusOK {
+		return nil, NewAPIError(resp)
+	}
+
+	var getResp models.GetMaterializeDeploymentResponse
+	if err := json.NewDecoder(resp.Response.Body).Decode(&getResp); err != nil {
+		return nil, fmt.Errorf("failed to decode materialize deployment response: %w", err)
+	}
+	return &getResp.Deployment, nil
+}
+
+// UpdateMaterializeDeployment updates a Materialize deployment's
+// configuration. The response carries no body, so callers should re-fetch
+// the deployment to observe the applied configuration.
+func (c *CloudClient) UpdateMaterializeDeployment(ctx context.Context, id string, updateReq *models.UpdateMaterializeDeploymentRequest) error {
+	resp, err := c.doMaterializeRequest(ctx, http.MethodPatch, fmt.Sprintf("/materialize/%s", id), updateReq)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Response.Body.Close()
+	}()
+
+	if resp.Response.StatusCode != http.StatusOK && resp.Response.StatusCode != http.StatusNoContent {
+		return NewAPIError(resp)
+	}
+	return nil
+}
+
+// DeleteMaterializeDeployment deletes a Materialize deployment. The API
+// answers 202 Accepted and deprovisions asynchronously; deletion also
+// removes the deployment's authorization relationships, after which the
+// API's permission check rejects reads of the deleted deployment with 403
+// instead of 404. A 403 on the DELETE itself is still a real permission
+// error — only after the DELETE was accepted does 403 mean "gone", which is
+// why this does not reuse the shared DeleteResource polling (its poll loop
+// treats 403 as a hard error).
+func (c *CloudClient) DeleteMaterializeDeployment(id string) error {
+	endpoint := fmt.Sprintf("/materialize/%s", id)
+
+	// DELETE is idempotent, so it rides the same 429/5xx retry funnel as the
+	// other verbs.
+	respWithETag, err := c.doMaterializeRequest(context.Background(), http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = respWithETag.Response.Body.Close()
+	}()
+
+	switch status := respWithETag.Response.StatusCode; status {
+	case http.StatusOK, http.StatusNoContent:
+		return nil
+	case http.StatusNotFound, http.StatusGone:
+		// Idempotent delete success.
+		return nil
+	case http.StatusAccepted:
+		return c.waitForMaterializeDeletion(endpoint)
+	default:
+		return NewAPIError(respWithETag)
+	}
+}
+
+// waitForMaterializeDeletion polls the deployment endpoint after an accepted
+// DELETE until it reads as gone. 404/410 mean the record is deleted; 403
+// means the deployment's authorization relationships were removed as part of
+// deletion (the caller was authorized moments ago, so a permission failure
+// here cannot mean anything else). Everything retryable (2xx while
+// deprovisioning, 409/412/429, 5xx, network errors) keeps polling within
+// the client's DeleteTimeout.
+func (c *CloudClient) waitForMaterializeDeletion(endpoint string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.DeleteTimeout)
+	defer cancel()
+
+	operation := func() error {
+		probeCtx, probeCancel := context.WithTimeout(ctx, 15*time.Second)
+		defer probeCancel()
+
+		req, err := c.NewRequest(http.MethodGet, endpoint, nil, WithAPIVersion(MaterializeAPIVersion))
+		if err != nil {
+			return backoff.Permanent(fmt.Errorf("failed to create request while polling for deletion: %w", err))
+		}
+		req = req.WithContext(probeCtx)
+
+		respWithETag, err := c.Do(req)
+		if err != nil {
+			// Network errors are retryable within the delete timeout.
+			return err
+		}
+		defer func() {
+			_ = respWithETag.Response.Body.Close()
+		}()
+
+		status := respWithETag.Response.StatusCode
+		switch {
+		// Gone: deleted record (404/410) or deleted authz relationships (403).
+		case status == http.StatusNotFound || status == http.StatusGone || status == http.StatusForbidden:
+			return nil
+		// Retryable: still present (2xx) or 409/412/429/5xx.
+		case (status >= 200 && status < 300) || status == http.StatusConflict || status == http.StatusPreconditionFailed || status == http.StatusTooManyRequests || status >= 500:
+			return fmt.Errorf("materialize deployment still present (status %d)", status)
+		default:
+			return backoff.Permanent(fmt.Errorf("unexpected status code %d while polling for materialize deployment deletion", status))
+		}
+	}
+
+	if err := backoff.Retry(operation, backoff.WithContext(NewPollBackOff(), ctx)); err != nil {
+		return fmt.Errorf("waiting for materialize deployment deletion at %s: %w", endpoint, err)
+	}
+	return nil
+}

--- a/internal/client/materialize_test.go
+++ b/internal/client/materialize_test.go
@@ -1,0 +1,448 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"terraform-provider-authzed/internal/models"
+)
+
+// newMaterializeTestClient returns a CloudClient pointed at an httptest server.
+func newMaterializeTestClient(t *testing.T, handler http.Handler) *CloudClient {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return NewCloudClient(&CloudClientConfig{
+		Host:          server.URL,
+		Token:         "test-token",
+		DeleteTimeout: 10 * time.Second,
+	})
+}
+
+func TestWithAPIVersionOverridesHeader(t *testing.T) {
+	var gotVersion atomic.Value
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotVersion.Store(r.Header.Get("X-API-Version"))
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req, err := c.NewRequest(http.MethodGet, "/materialize/mc-123", nil, WithAPIVersion(MaterializeAPIVersion))
+	if err != nil {
+		t.Fatalf("NewRequest failed: %v", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	_ = resp.Response.Body.Close()
+
+	if got := gotVersion.Load(); got != "internal" {
+		t.Fatalf("expected X-API-Version %q, got %q", "internal", got)
+	}
+}
+
+func TestDeleteResourcePassesOptionsToAllRequests(t *testing.T) {
+	var deleteCalls, getCalls int32
+	var badVersions int32
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Version") != "internal" {
+			atomic.AddInt32(&badVersions, 1)
+		}
+		switch r.Method {
+		case http.MethodDelete:
+			atomic.AddInt32(&deleteCalls, 1)
+			w.WriteHeader(http.StatusAccepted) // async delete
+		case http.MethodGet:
+			// First poll: still present; afterwards: gone.
+			if atomic.AddInt32(&getCalls, 1) == 1 {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	if err := c.DeleteResource("/materialize/mc-123", WithAPIVersion(MaterializeAPIVersion)); err != nil {
+		t.Fatalf("DeleteResource failed: %v", err)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("expected 1 DELETE, got %d", deleteCalls)
+	}
+	if getCalls < 2 {
+		t.Fatalf("expected at least 2 polling GETs, got %d", getCalls)
+	}
+	if badVersions != 0 {
+		t.Fatalf("%d requests were sent without X-API-Version: internal", badVersions)
+	}
+}
+
+func TestCreateMaterializeDeployment(t *testing.T) {
+	var gotBody models.CreateMaterializeDeploymentRequest
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/materialize" {
+			t.Errorf("expected POST /materialize, got %s %s", r.Method, r.URL.Path)
+		}
+		if v := r.Header.Get("X-API-Version"); v != "internal" {
+			t.Errorf("expected X-API-Version internal, got %q", v)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id": "mc-abc123", "deploymentID": "dp-xyz", "name": "my-materialize"}`)
+	}))
+
+	replicas := int64(2)
+	accelerated := true
+	created, err := c.CreateMaterializeDeployment(context.Background(), &models.CreateMaterializeDeploymentRequest{
+		PermissionsSystemID: "ps-xyz",
+		DeploymentID:        "dp-xyz",
+		ServerTemplateID:    "mtsc-default",
+		SnapshotTemplateID:  "mtssc-default",
+		HydrationTemplateID: "mthc-default",
+		Name:                "my-materialize",
+		WatchedPermissions:  []string{"document#view@user"},
+		Replicas:            &replicas,
+		AcceleratedQueries:  &accelerated,
+	})
+	if err != nil {
+		t.Fatalf("CreateMaterializeDeployment failed: %v", err)
+	}
+	if created.ID != "mc-abc123" {
+		t.Fatalf("expected id mc-abc123, got %q", created.ID)
+	}
+	if gotBody.Name != "my-materialize" || gotBody.PermissionsSystemID != "ps-xyz" ||
+		gotBody.DeploymentID != "dp-xyz" || gotBody.ServerTemplateID != "mtsc-default" ||
+		gotBody.SnapshotTemplateID != "mtssc-default" || gotBody.HydrationTemplateID != "mthc-default" {
+		t.Fatalf("request body missing required fields: %+v", gotBody)
+	}
+	if gotBody.Replicas == nil || *gotBody.Replicas != 2 {
+		t.Fatalf("expected replicas pointer 2, got %v", gotBody.Replicas)
+	}
+	if gotBody.AcceleratedQueries == nil || !*gotBody.AcceleratedQueries {
+		t.Fatalf("expected acceleratedQueries pointer true, got %v", gotBody.AcceleratedQueries)
+	}
+}
+
+func TestCreateMaterializeDeploymentOmitsNilOptionals(t *testing.T) {
+	var rawBody map[string]any
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&rawBody)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id": "mc-abc123", "deploymentID": "dp-xyz", "name": "n"}`)
+	}))
+
+	_, err := c.CreateMaterializeDeployment(context.Background(), &models.CreateMaterializeDeploymentRequest{
+		PermissionsSystemID: "ps-xyz",
+		DeploymentID:        "dp-xyz",
+		ServerTemplateID:    "mtsc-default",
+		SnapshotTemplateID:  "mtssc-default",
+		HydrationTemplateID: "mthc-default",
+		Name:                "n",
+		WatchedPermissions:  []string{"document#view@user"},
+	})
+	if err != nil {
+		t.Fatalf("CreateMaterializeDeployment failed: %v", err)
+	}
+	for _, key := range []string{"replicas", "acceleratedQueries", "enableEventStreams", "downloadPermissionSetsFormats"} {
+		if _, present := rawBody[key]; present {
+			t.Errorf("expected %q to be omitted from request body, got %v", key, rawBody[key])
+		}
+	}
+}
+
+func TestGetMaterializeDeployment(t *testing.T) {
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/materialize/mc-abc123" {
+			t.Errorf("expected GET /materialize/mc-abc123, got %s %s", r.Method, r.URL.Path)
+		}
+		if v := r.Header.Get("X-API-Version"); v != "internal" {
+			t.Errorf("expected X-API-Version internal, got %q", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"deployment": {
+			"id": "mc-abc123",
+			"name": "my-materialize",
+			"permissionsSystemID": "ps-xyz",
+			"deploymentID": "dp-xyz",
+			"serverTemplateID": "mtsc-default",
+			"snapshotTemplateID": "mtssc-default",
+			"hydrationTemplateID": "mthc-default",
+			"watchedPermissions": ["document#view@user"],
+			"url": "https://mc-abc123.example.com",
+			"createdAt": "2026-07-13T00:00:00Z",
+			"status": {
+				"phase": "Running",
+				"features": {"acceleratedQueries": true, "eventStreams": false},
+				"compute": {"cacheServer": {"cpu": "4", "memory": "8Gi", "replicas": 2}}
+			}
+		}}`)
+	}))
+
+	deployment, err := c.GetMaterializeDeployment(context.Background(), "mc-abc123")
+	if err != nil {
+		t.Fatalf("GetMaterializeDeployment failed: %v", err)
+	}
+	if deployment.ID != "mc-abc123" || deployment.Name != "my-materialize" {
+		t.Fatalf("unexpected deployment identity: %+v", deployment)
+	}
+	if deployment.ServerTemplateID != "mtsc-default" {
+		t.Fatalf("expected serverTemplateID mtsc-default, got %q", deployment.ServerTemplateID)
+	}
+	if len(deployment.WatchedPermissions) != 1 || deployment.WatchedPermissions[0] != "document#view@user" {
+		t.Fatalf("unexpected watchedPermissions: %v", deployment.WatchedPermissions)
+	}
+	if deployment.Status == nil || deployment.Status.Phase != models.MaterializePhaseRunning {
+		t.Fatalf("expected Running status, got %+v", deployment.Status)
+	}
+	if deployment.Status.Features == nil || !deployment.Status.Features.AcceleratedQueries {
+		t.Fatalf("expected acceleratedQueries true, got %+v", deployment.Status.Features)
+	}
+	if deployment.Status.Compute == nil || deployment.Status.Compute.CacheServer == nil ||
+		deployment.Status.Compute.CacheServer.Replicas == nil || *deployment.Status.Compute.CacheServer.Replicas != 2 {
+		t.Fatalf("expected cacheServer replicas 2, got %+v", deployment.Status.Compute)
+	}
+}
+
+// GET is idempotent, so transient 5xx responses retry.
+func TestGetMaterializeDeploymentRetriesOn5xx(t *testing.T) {
+	var calls int32
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"deployment": {"id": "mc-abc123", "name": "n", "permissionsSystemID": "ps-x", "deploymentID": "dp-x", "watchedPermissions": []}}`)
+	}))
+
+	deployment, err := c.GetMaterializeDeployment(context.Background(), "mc-abc123")
+	if err != nil {
+		t.Fatalf("expected retry to recover from 503, got: %v", err)
+	}
+	if deployment.ID != "mc-abc123" {
+		t.Fatalf("unexpected deployment: %+v", deployment)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls (503 then 200), got %d", calls)
+	}
+}
+
+// POST must not retry an ambiguous 5xx: the create may have been processed
+// server-side, and a retry could create a duplicate deployment.
+func TestCreateMaterializeDeploymentDoesNotRetryOn5xx(t *testing.T) {
+	var calls int32
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+
+	_, err := c.CreateMaterializeDeployment(context.Background(), &models.CreateMaterializeDeploymentRequest{
+		PermissionsSystemID: "ps-x",
+		DeploymentID:        "dp-x",
+		ServerTemplateID:    "mtsc-default",
+		SnapshotTemplateID:  "mtssc-default",
+		HydrationTemplateID: "mthc-default",
+		Name:                "n",
+		WatchedPermissions:  []string{"document#view@user"},
+	})
+	if err == nil {
+		t.Fatal("expected error for 502 on POST, got nil")
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 POST attempt (no retry on ambiguous 5xx), got %d", calls)
+	}
+}
+
+// POST retries on 429: the request provably was not processed.
+func TestCreateMaterializeDeploymentRetriesOn429(t *testing.T) {
+	var calls int32
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id": "mc-abc123", "deploymentID": "dp-x", "name": "n"}`)
+	}))
+
+	created, err := c.CreateMaterializeDeployment(context.Background(), &models.CreateMaterializeDeploymentRequest{
+		PermissionsSystemID: "ps-x",
+		DeploymentID:        "dp-x",
+		ServerTemplateID:    "mtsc-default",
+		SnapshotTemplateID:  "mtssc-default",
+		HydrationTemplateID: "mthc-default",
+		Name:                "n",
+		WatchedPermissions:  []string{"document#view@user"},
+	})
+	if err != nil {
+		t.Fatalf("expected retry to recover from 429, got: %v", err)
+	}
+	if created.ID != "mc-abc123" {
+		t.Fatalf("unexpected create response: %+v", created)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls (429 then 201), got %d", calls)
+	}
+}
+
+func TestGetMaterializeDeploymentNotFound(t *testing.T) {
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	_, err := c.GetMaterializeDeployment(context.Background(), "mc-missing")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "status 404") {
+		t.Fatalf("expected error to contain 'status 404', got: %v", err)
+	}
+}
+
+func TestUpdateMaterializeDeployment(t *testing.T) {
+	var gotBody map[string]any
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || r.URL.Path != "/materialize/mc-abc123" {
+			t.Errorf("expected PATCH /materialize/mc-abc123, got %s %s", r.Method, r.URL.Path)
+		}
+		if v := r.Header.Get("X-API-Version"); v != "internal" {
+			t.Errorf("expected X-API-Version internal, got %q", v)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK) // empty body per spec
+	}))
+
+	replicas := int64(3)
+	serverTemplateID := "mtsc-large"
+	err := c.UpdateMaterializeDeployment(context.Background(), "mc-abc123", &models.UpdateMaterializeDeploymentRequest{
+		ServerTemplateID: &serverTemplateID,
+		Replicas:         &replicas,
+	})
+	if err != nil {
+		t.Fatalf("UpdateMaterializeDeployment failed: %v", err)
+	}
+	if gotBody["serverTemplateID"] != "mtsc-large" {
+		t.Fatalf("expected serverTemplateID mtsc-large, got %v", gotBody["serverTemplateID"])
+	}
+	if gotBody["replicas"] != float64(3) {
+		t.Fatalf("expected replicas 3, got %v", gotBody["replicas"])
+	}
+	for _, key := range []string{"snapshotTemplateID", "hydrationTemplateID", "watchedPermissions", "acceleratedQueries"} {
+		if _, present := gotBody[key]; present {
+			t.Errorf("expected omitted field %q to be absent, got %v", key, gotBody[key])
+		}
+	}
+}
+
+func TestUpdateMaterializeDeploymentError(t *testing.T) {
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+
+	serverTemplateID := "mtsc-bogus"
+	err := c.UpdateMaterializeDeployment(context.Background(), "mc-abc123", &models.UpdateMaterializeDeploymentRequest{
+		ServerTemplateID: &serverTemplateID,
+	})
+	if err == nil {
+		t.Fatal("expected error for 400, got nil")
+	}
+	if !strings.Contains(err.Error(), "status 400") {
+		t.Fatalf("expected error to contain 'status 400', got: %v", err)
+	}
+}
+
+func TestDeleteMaterializeDeploymentAsync(t *testing.T) {
+	var getCalls int32
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Header.Get("X-API-Version"); v != "internal" {
+			t.Errorf("expected X-API-Version internal on %s, got %q", r.Method, v)
+		}
+		switch r.Method {
+		case http.MethodDelete:
+			if r.URL.Path != "/materialize/mc-abc123" {
+				t.Errorf("expected DELETE /materialize/mc-abc123, got %s", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusAccepted)
+		case http.MethodGet:
+			if atomic.AddInt32(&getCalls, 1) == 1 {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	if err := c.DeleteMaterializeDeployment("mc-abc123"); err != nil {
+		t.Fatalf("DeleteMaterializeDeployment failed: %v", err)
+	}
+	if getCalls < 2 {
+		t.Fatalf("expected polling until 404, got %d GETs", getCalls)
+	}
+}
+
+// Deleting a materialize deployment removes its authorization relationships,
+// so polls for the deleted deployment fail the API's permission check with
+// 403 rather than 404. After an accepted DELETE that must count as gone.
+func TestDeleteMaterializeDeploymentAsync403MeansGone(t *testing.T) {
+	var getCalls int32
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusAccepted)
+		case http.MethodGet:
+			// Still deprovisioning on the first poll, then the authz
+			// relationships are gone and the API answers 403 forever.
+			if atomic.AddInt32(&getCalls, 1) == 1 {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			w.WriteHeader(http.StatusForbidden)
+		}
+	}))
+
+	if err := c.DeleteMaterializeDeployment("mc-abc123"); err != nil {
+		t.Fatalf("DeleteMaterializeDeployment failed on 403 poll: %v", err)
+	}
+	if getCalls < 2 {
+		t.Fatalf("expected polling until 403, got %d GETs", getCalls)
+	}
+}
+
+// A 403 on the DELETE request itself is a genuine permission error, not a
+// deletion signal.
+func TestDeleteMaterializeDeploymentForbidden(t *testing.T) {
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+
+	err := c.DeleteMaterializeDeployment("mc-abc123")
+	if err == nil {
+		t.Fatal("expected error for 403 on DELETE, got nil")
+	}
+	if !strings.Contains(err.Error(), "status 403") {
+		t.Fatalf("expected error to contain 'status 403', got: %v", err)
+	}
+}
+
+// A DELETE answered with 404 is an idempotent success (already gone).
+func TestDeleteMaterializeDeploymentIdempotent(t *testing.T) {
+	c := newMaterializeTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	if err := c.DeleteMaterializeDeployment("mc-abc123"); err != nil {
+		t.Fatalf("expected idempotent success on 404 DELETE, got: %v", err)
+	}
+}

--- a/internal/models/materialize.go
+++ b/internal/models/materialize.go
@@ -1,0 +1,96 @@
+package models
+
+// MaterializePhaseRunning is the deployment phase indicating the Materialize
+// deployment is provisioned and serving.
+const MaterializePhaseRunning = "Running"
+
+// Materialize job phases reported for the snapshot and hydration jobs.
+const (
+	MaterializeJobPhaseRunning  = "Running"
+	MaterializeJobPhaseComplete = "Complete"
+	MaterializeJobPhaseDisabled = "Disabled"
+)
+
+// MaterializeDeployment represents a Materialize deployment as returned by the API
+type MaterializeDeployment struct {
+	ID                  string                       `json:"id"`
+	Name                string                       `json:"name"`
+	PermissionsSystemID string                       `json:"permissionsSystemID"`
+	DeploymentID        string                       `json:"deploymentID"`
+	ServerTemplateID    string                       `json:"serverTemplateID,omitempty"`
+	SnapshotTemplateID  string                       `json:"snapshotTemplateID,omitempty"`
+	HydrationTemplateID string                       `json:"hydrationTemplateID,omitempty"`
+	WatchedPermissions  []string                     `json:"watchedPermissions"`
+	URL                 string                       `json:"url,omitempty"`
+	CreatedAt           string                       `json:"createdAt,omitempty"`
+	Status              *MaterializeDeploymentStatus `json:"status,omitempty"`
+}
+
+// MaterializeDeploymentStatus is the subset of the deployment status the
+// provider reads: the health phase, the snapshot job state used as the
+// create-readiness signal, plus the feature flags and compute that mirror
+// configurable attributes back for drift detection.
+type MaterializeDeploymentStatus struct {
+	Phase    string                             `json:"phase,omitempty"`
+	Snapshot *MaterializeDeploymentSnapshotInfo `json:"snapshot,omitempty"`
+	Features *MaterializeDeploymentFeatures     `json:"features,omitempty"`
+	Compute  *MaterializeDeploymentCompute      `json:"compute,omitempty"`
+}
+
+// MaterializeDeploymentSnapshotInfo reports the state of the snapshot job
+type MaterializeDeploymentSnapshotInfo struct {
+	Phase string `json:"phase,omitempty"`
+}
+
+// MaterializeDeploymentFeatures reports which optional features are enabled
+type MaterializeDeploymentFeatures struct {
+	AcceleratedQueries bool `json:"acceleratedQueries"`
+}
+
+// MaterializeDeploymentCompute is the per-component compute breakdown
+type MaterializeDeploymentCompute struct {
+	CacheServer *MaterializeComponentCompute `json:"cacheServer,omitempty"`
+}
+
+// MaterializeComponentCompute describes one component's provisioned compute
+type MaterializeComponentCompute struct {
+	Replicas *int64 `json:"replicas,omitempty"`
+}
+
+// GetMaterializeDeploymentResponse wraps the deployment returned by GET
+type GetMaterializeDeploymentResponse struct {
+	Deployment MaterializeDeployment `json:"deployment"`
+}
+
+// CreateMaterializeDeploymentRequest is the body for POST /materialize.
+// Nil optional pointers are omitted, which the API interprets as "use the
+// server template default".
+type CreateMaterializeDeploymentRequest struct {
+	PermissionsSystemID string   `json:"permissionsSystemID"`
+	DeploymentID        string   `json:"deploymentID"`
+	ServerTemplateID    string   `json:"serverTemplateID"`
+	SnapshotTemplateID  string   `json:"snapshotTemplateID"`
+	HydrationTemplateID string   `json:"hydrationTemplateID"`
+	Name                string   `json:"name"`
+	WatchedPermissions  []string `json:"watchedPermissions"`
+	Replicas            *int64   `json:"replicas,omitempty"`
+	AcceleratedQueries  *bool    `json:"acceleratedQueries,omitempty"`
+}
+
+// CreateMaterializeDeploymentResponse is the body returned by POST /materialize
+type CreateMaterializeDeploymentResponse struct {
+	ID           string `json:"id"`
+	DeploymentID string `json:"deploymentID"`
+	Name         string `json:"name"`
+}
+
+// UpdateMaterializeDeploymentRequest is the body for PATCH /materialize/{id}.
+// Nil pointers are omitted, which the API interprets as "leave unchanged".
+type UpdateMaterializeDeploymentRequest struct {
+	ServerTemplateID    *string   `json:"serverTemplateID,omitempty"`
+	SnapshotTemplateID  *string   `json:"snapshotTemplateID,omitempty"`
+	HydrationTemplateID *string   `json:"hydrationTemplateID,omitempty"`
+	WatchedPermissions  *[]string `json:"watchedPermissions,omitempty"`
+	Replicas            *int64    `json:"replicas,omitempty"`
+	AcceleratedQueries  *bool     `json:"acceleratedQueries,omitempty"`
+}

--- a/internal/provider/materialize_deployment_mapping_test.go
+++ b/internal/provider/materialize_deployment_mapping_test.go
@@ -1,0 +1,165 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-authzed/internal/models"
+)
+
+func fullTestDeployment() *models.MaterializeDeployment {
+	replicas := int64(2)
+	return &models.MaterializeDeployment{
+		ID:                  "mc-abc123",
+		Name:                "my-materialize",
+		PermissionsSystemID: "ps-xyz",
+		DeploymentID:        "dp-xyz",
+		ServerTemplateID:    "mtsc-default",
+		SnapshotTemplateID:  "mtssc-default",
+		HydrationTemplateID: "mthc-default",
+		WatchedPermissions:  []string{"document#view@user"},
+		URL:                 "https://mc-abc123.example.com",
+		CreatedAt:           "2026-07-13T00:00:00Z",
+		Status: &models.MaterializeDeploymentStatus{
+			Phase:    models.MaterializePhaseRunning,
+			Features: &models.MaterializeDeploymentFeatures{AcceleratedQueries: true},
+			Compute: &models.MaterializeDeploymentCompute{
+				CacheServer: &models.MaterializeComponentCompute{Replicas: &replicas},
+			},
+		},
+	}
+}
+
+func TestApplyMaterializeDeploymentToModelFull(t *testing.T) {
+	var data materializeDeploymentResourceModel
+	diags := applyMaterializeDeploymentToModel(context.Background(), fullTestDeployment(), &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if data.ID.ValueString() != "mc-abc123" || data.Name.ValueString() != "my-materialize" {
+		t.Fatalf("identity not mapped: %+v", data)
+	}
+	if data.PermissionSystemID.ValueString() != "ps-xyz" || data.DeploymentID.ValueString() != "dp-xyz" {
+		t.Fatalf("references not mapped: %+v", data)
+	}
+	if data.ServerTemplateID.ValueString() != "mtsc-default" ||
+		data.SnapshotTemplateID.ValueString() != "mtssc-default" ||
+		data.HydrationTemplateID.ValueString() != "mthc-default" {
+		t.Fatalf("templates not mapped: %+v", data)
+	}
+	if data.URL.ValueString() != "https://mc-abc123.example.com" || data.CreatedAt.ValueString() != "2026-07-13T00:00:00Z" {
+		t.Fatalf("computed fields not mapped: %+v", data)
+	}
+	if !data.AcceleratedQueries.ValueBool() {
+		t.Fatalf("expected accelerated_queries true, got %v", data.AcceleratedQueries)
+	}
+	if data.Replicas.ValueInt64() != 2 {
+		t.Fatalf("expected replicas 2, got %v", data.Replicas)
+	}
+	var watched []string
+	if d := data.WatchedPermissions.ElementsAs(context.Background(), &watched, false); d.HasError() {
+		t.Fatalf("watched_permissions not a string list: %v", d)
+	}
+	if len(watched) != 1 || watched[0] != "document#view@user" {
+		t.Fatalf("unexpected watched_permissions: %v", watched)
+	}
+}
+
+// When status sub-objects are missing (transiently unresolved), known prior
+// values must be preserved rather than overwritten with null.
+func TestApplyMaterializeDeploymentToModelPreservesKnownValues(t *testing.T) {
+	deployment := fullTestDeployment()
+	deployment.Status = nil
+	deployment.ServerTemplateID = ""
+	deployment.SnapshotTemplateID = ""
+	deployment.HydrationTemplateID = ""
+	deployment.URL = ""
+	deployment.CreatedAt = ""
+
+	data := materializeDeploymentResourceModel{
+		ServerTemplateID:    types.StringValue("mtsc-prior"),
+		SnapshotTemplateID:  types.StringValue("mtssc-prior"),
+		HydrationTemplateID: types.StringValue("mthc-prior"),
+		Replicas:            types.Int64Value(4),
+		AcceleratedQueries:  types.BoolValue(true),
+		URL:                 types.StringValue("https://prior.example.com"),
+		CreatedAt:           types.StringValue("2026-01-01T00:00:00Z"),
+	}
+	diags := applyMaterializeDeploymentToModel(context.Background(), deployment, &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if data.ServerTemplateID.ValueString() != "mtsc-prior" {
+		t.Fatalf("expected prior server template preserved, got %v", data.ServerTemplateID)
+	}
+	if data.SnapshotTemplateID.ValueString() != "mtssc-prior" {
+		t.Fatalf("expected prior snapshot template preserved, got %v", data.SnapshotTemplateID)
+	}
+	if data.HydrationTemplateID.ValueString() != "mthc-prior" {
+		t.Fatalf("expected prior hydration template preserved, got %v", data.HydrationTemplateID)
+	}
+	if data.Replicas.ValueInt64() != 4 {
+		t.Fatalf("expected prior replicas preserved, got %v", data.Replicas)
+	}
+	if !data.AcceleratedQueries.ValueBool() {
+		t.Fatalf("expected prior accelerated_queries preserved, got %v", data.AcceleratedQueries)
+	}
+	if data.URL.ValueString() != "https://prior.example.com" {
+		t.Fatalf("expected prior url preserved, got %v", data.URL)
+	}
+	if data.CreatedAt.ValueString() != "2026-01-01T00:00:00Z" {
+		t.Fatalf("expected prior created_at preserved, got %v", data.CreatedAt)
+	}
+}
+
+// Unknown values cannot be persisted to state, so when the API provides
+// nothing they must resolve to null, not stay unknown.
+func TestApplyMaterializeDeploymentToModelResolvesUnknowns(t *testing.T) {
+	deployment := fullTestDeployment()
+	deployment.Status = nil
+	deployment.ServerTemplateID = ""
+	deployment.SnapshotTemplateID = ""
+	deployment.HydrationTemplateID = ""
+	deployment.URL = ""
+	deployment.CreatedAt = ""
+
+	data := materializeDeploymentResourceModel{
+		ServerTemplateID:    types.StringUnknown(),
+		SnapshotTemplateID:  types.StringUnknown(),
+		HydrationTemplateID: types.StringUnknown(),
+		Replicas:            types.Int64Unknown(),
+		AcceleratedQueries:  types.BoolUnknown(),
+		URL:                 types.StringUnknown(),
+		CreatedAt:           types.StringUnknown(),
+	}
+	diags := applyMaterializeDeploymentToModel(context.Background(), deployment, &data)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+
+	if !data.ServerTemplateID.IsNull() {
+		t.Fatalf("expected server template resolved to null, got %v", data.ServerTemplateID)
+	}
+	if !data.SnapshotTemplateID.IsNull() {
+		t.Fatalf("expected snapshot template resolved to null, got %v", data.SnapshotTemplateID)
+	}
+	if !data.HydrationTemplateID.IsNull() {
+		t.Fatalf("expected hydration template resolved to null, got %v", data.HydrationTemplateID)
+	}
+	if !data.Replicas.IsNull() {
+		t.Fatalf("expected replicas resolved to null, got %v", data.Replicas)
+	}
+	if !data.AcceleratedQueries.IsNull() {
+		t.Fatalf("expected accelerated_queries resolved to null, got %v", data.AcceleratedQueries)
+	}
+	if !data.URL.IsNull() {
+		t.Fatalf("expected url resolved to null, got %v", data.URL)
+	}
+	if !data.CreatedAt.IsNull() {
+		t.Fatalf("expected created_at resolved to null, got %v", data.CreatedAt)
+	}
+}

--- a/internal/provider/materialize_deployment_resource.go
+++ b/internal/provider/materialize_deployment_resource.go
@@ -1,0 +1,485 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"terraform-provider-authzed/internal/client"
+	"terraform-provider-authzed/internal/models"
+)
+
+var (
+	_ resource.Resource                = &materializeDeploymentResource{}
+	_ resource.ResourceWithImportState = &materializeDeploymentResource{}
+)
+
+func NewMaterializeDeploymentResource() resource.Resource {
+	return &materializeDeploymentResource{}
+}
+
+type materializeDeploymentResource struct {
+	client *client.CloudClient
+}
+
+type materializeDeploymentResourceModel struct {
+	ID                  types.String   `tfsdk:"id"`
+	Name                types.String   `tfsdk:"name"`
+	PermissionSystemID  types.String   `tfsdk:"permission_system_id"`
+	DeploymentID        types.String   `tfsdk:"deployment_id"`
+	ServerTemplateID    types.String   `tfsdk:"server_template_id"`
+	SnapshotTemplateID  types.String   `tfsdk:"snapshot_template_id"`
+	HydrationTemplateID types.String   `tfsdk:"hydration_template_id"`
+	WatchedPermissions  types.List     `tfsdk:"watched_permissions"`
+	Replicas            types.Int64    `tfsdk:"replicas"`
+	AcceleratedQueries  types.Bool     `tfsdk:"accelerated_queries"`
+	URL                 types.String   `tfsdk:"url"`
+	CreatedAt           types.String   `tfsdk:"created_at"`
+	Timeouts            timeouts.Value `tfsdk:"timeouts"`
+}
+
+// The *OrPreserve helpers implement the read-back rule shared by every
+// asymmetric attribute: an API-provided value wins; an absent one keeps the
+// model's current value — except values that are still unknown, which must
+// resolve to null because unknowns cannot be persisted to state.
+
+func stringOrPreserve(apiValue string, current types.String) types.String {
+	if apiValue != "" {
+		return types.StringValue(apiValue)
+	}
+	if current.IsUnknown() {
+		return types.StringNull()
+	}
+	return current
+}
+
+func boolOrPreserve(apiValue *bool, current types.Bool) types.Bool {
+	if apiValue != nil {
+		return types.BoolValue(*apiValue)
+	}
+	if current.IsUnknown() {
+		return types.BoolNull()
+	}
+	return current
+}
+
+func int64OrPreserve(apiValue *int64, current types.Int64) types.Int64 {
+	if apiValue != nil {
+		return types.Int64Value(*apiValue)
+	}
+	if current.IsUnknown() {
+		return types.Int64Null()
+	}
+	return current
+}
+
+// applyMaterializeDeploymentToModel maps API fields onto the resource model.
+// GET composes template IDs, features, and compute best-effort (they can be
+// transiently absent while the operator resolves the spec), so absent values
+// follow the *OrPreserve rule above.
+func applyMaterializeDeploymentToModel(ctx context.Context, deployment *models.MaterializeDeployment, data *materializeDeploymentResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	data.ID = types.StringValue(deployment.ID)
+	data.Name = types.StringValue(deployment.Name)
+	data.PermissionSystemID = types.StringValue(deployment.PermissionsSystemID)
+	data.DeploymentID = types.StringValue(deployment.DeploymentID)
+
+	data.ServerTemplateID = stringOrPreserve(deployment.ServerTemplateID, data.ServerTemplateID)
+	data.SnapshotTemplateID = stringOrPreserve(deployment.SnapshotTemplateID, data.SnapshotTemplateID)
+	data.HydrationTemplateID = stringOrPreserve(deployment.HydrationTemplateID, data.HydrationTemplateID)
+	data.URL = stringOrPreserve(deployment.URL, data.URL)
+	data.CreatedAt = stringOrPreserve(deployment.CreatedAt, data.CreatedAt)
+
+	watched, d := types.ListValueFrom(ctx, types.StringType, deployment.WatchedPermissions)
+	diags.Append(d...)
+	data.WatchedPermissions = watched
+
+	var acceleratedQueries *bool
+	if deployment.Status != nil && deployment.Status.Features != nil {
+		acceleratedQueries = &deployment.Status.Features.AcceleratedQueries
+	}
+	data.AcceleratedQueries = boolOrPreserve(acceleratedQueries, data.AcceleratedQueries)
+
+	var replicas *int64
+	if deployment.Status != nil && deployment.Status.Compute != nil && deployment.Status.Compute.CacheServer != nil {
+		replicas = deployment.Status.Compute.CacheServer.Replicas
+	}
+	data.Replicas = int64OrPreserve(replicas, data.Replicas)
+
+	return diags
+}
+
+// optionalInt64/optionalBool convert an optional attribute to the request's
+// pointer form: nil when the plan leaves the value to the server.
+
+func optionalInt64(v types.Int64) *int64 {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	value := v.ValueInt64()
+	return &value
+}
+
+func optionalBool(v types.Bool) *bool {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	value := v.ValueBool()
+	return &value
+}
+
+// applyPlannedOverrides restores plan-specified values for the
+// optional+computed attributes after a post-apply read: the API accepted the
+// requested configuration, and the just-read status is composed
+// asynchronously and may still be stale. Read detects real drift later.
+func applyPlannedOverrides(data *materializeDeploymentResourceModel, plannedReplicas types.Int64, plannedAcceleratedQueries types.Bool) {
+	if !plannedReplicas.IsNull() && !plannedReplicas.IsUnknown() {
+		data.Replicas = plannedReplicas
+	}
+	if !plannedAcceleratedQueries.IsNull() && !plannedAcceleratedQueries.IsUnknown() {
+		data.AcceleratedQueries = plannedAcceleratedQueries
+	}
+}
+
+func (r *materializeDeploymentResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_materialize_deployment"
+}
+
+func (r *materializeDeploymentResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages an AuthZed Materialize deployment for a permission system deployment. Requires the internal API version, which the provider sends automatically for this resource. The internal API comes with no compatibility guarantees and can change or break at any time without notice; promotion to the public API is planned to align with the Materialize GA release.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Unique identifier for this Materialize deployment (mc-...)",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name of the Materialize deployment (RFC-1123, max 50 chars). Changing it forces replacement.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"permission_system_id": schema.StringAttribute{
+				Required:    true,
+				Description: "ID of the permission system this Materialize deployment watches (ps-...). Changing it forces replacement.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"deployment_id": schema.StringAttribute{
+				Required:    true,
+				Description: "ID of the permission system deployment providing updates (dp-...). Changing it forces replacement.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"server_template_id": schema.StringAttribute{
+				Required:    true,
+				Description: "ID of the Materialize online hydration server template (e.g. mtsc-4-vcpu)",
+			},
+			"snapshot_template_id": schema.StringAttribute{
+				Required:    true,
+				Description: "ID of the Materialize snapshot template (e.g. mtssc-4-vcpu)",
+			},
+			"hydration_template_id": schema.StringAttribute{
+				Required:    true,
+				Description: "ID of the Materialize offline hydration template (e.g. mthc-4-vcpu)",
+			},
+			"watched_permissions": schema.ListAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				Description: "Permissions to materialize, in the format resource_type#relation@subject_type[#subject_relation] (1-100 entries). Updates replace the entire list.",
+			},
+			"replicas": schema.Int64Attribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Number of online hydration server replicas (0-16). Zero temporarily disables the deployment without deleting it. Omitted uses the server template default.",
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
+			"accelerated_queries": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Whether this deployment accelerates the permission system's CheckPermission, LookupResources, and LookupSubjects queries by serving as a hedged, lower-latency cache.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"url": schema.StringAttribute{
+				Computed:    true,
+				Description: "Endpoint URL of the Materialize deployment",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp when the Materialize deployment was created",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+			}),
+		},
+	}
+}
+
+func (r *materializeDeploymentResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	providerData, ok := req.ProviderData.(*CloudProviderData)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *CloudProviderData, got: %T", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = providerData.Client
+}
+
+func (r *materializeDeploymentResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data materializeDeploymentResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Create waits until the deployment is provisioned and snapshotting —
+	// not fully hydrated, which is data-dependent and can take hours. The
+	// 30m here is only the default: users override it with the resource's
+	// `timeouts { create = "..." }` block.
+	createTimeout, diags := data.Timeouts.Create(ctx, 30*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
+	// Capture plan-specified values before any demotion; after the
+	// post-apply read they take precedence over possibly-stale status.
+	plannedReplicas := data.Replicas
+	plannedAcceleratedQueries := data.AcceleratedQueries
+
+	var watched []string
+	resp.Diagnostics.Append(data.WatchedPermissions.ElementsAs(ctx, &watched, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createReq := &models.CreateMaterializeDeploymentRequest{
+		PermissionsSystemID: data.PermissionSystemID.ValueString(),
+		DeploymentID:        data.DeploymentID.ValueString(),
+		ServerTemplateID:    data.ServerTemplateID.ValueString(),
+		SnapshotTemplateID:  data.SnapshotTemplateID.ValueString(),
+		HydrationTemplateID: data.HydrationTemplateID.ValueString(),
+		Name:                data.Name.ValueString(),
+		WatchedPermissions:  watched,
+		Replicas:            optionalInt64(data.Replicas),
+		AcceleratedQueries:  optionalBool(data.AcceleratedQueries),
+	}
+
+	created, err := r.client.CreateMaterializeDeployment(createCtx, createReq)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create materialize deployment, got error: %s", err))
+		return
+	}
+
+	// Persist the ID before waiting so a failed wait leaves a tainted
+	// resource in state instead of an untracked deployment.
+	data.ID = types.StringValue(created.ID)
+	data.URL = types.StringNull()
+	data.CreatedAt = types.StringNull()
+	data.Replicas = int64OrPreserve(nil, data.Replicas)
+	data.AcceleratedQueries = boolOrPreserve(nil, data.AcceleratedQueries)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// The wait's final poll returns the deployment it observed, so no extra
+	// read is needed afterwards.
+	deployment, err := waitForMaterializeDeploymentReady(createCtx, r.client, created.ID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Materialize Deployment Not Ready",
+			fmt.Sprintf("Deployment %s was created but did not start snapshotting: %s. Increase the create timeout if provisioning needs more time.", created.ID, err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(applyMaterializeDeploymentToModel(ctx, deployment, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	applyPlannedOverrides(&data, plannedReplicas, plannedAcceleratedQueries)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *materializeDeploymentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data materializeDeploymentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deployment, err := r.client.GetMaterializeDeployment(ctx, data.ID.ValueString())
+	if err != nil {
+		if materializeDeploymentGone(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read materialize deployment, got error: %s", err))
+		return
+	}
+
+	resp.Diagnostics.Append(applyMaterializeDeploymentToModel(ctx, deployment, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *materializeDeploymentResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data materializeDeploymentResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	var state materializeDeploymentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// The 30m here is only the default: users override it with the
+	// resource's `timeouts { update = "..." }` block.
+	updateTimeout, diags := data.Timeouts.Update(ctx, 30*time.Minute)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	updateCtx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
+
+	// Capture plan-specified values before any demotion; after the
+	// post-apply read they take precedence over possibly-stale status.
+	plannedReplicas := data.Replicas
+	plannedAcceleratedQueries := data.AcceleratedQueries
+
+	var watched []string
+	resp.Diagnostics.Append(data.WatchedPermissions.ElementsAs(ctx, &watched, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Send only the fields whose planned value differs from state; the API
+	// treats omitted fields as "leave unchanged", and PATCHing an unchanged
+	// template would needlessly re-resolve it.
+	updateReq := &models.UpdateMaterializeDeploymentRequest{}
+	hasAPIChanges := false
+	if !data.ServerTemplateID.Equal(state.ServerTemplateID) {
+		serverTemplateID := data.ServerTemplateID.ValueString()
+		updateReq.ServerTemplateID = &serverTemplateID
+		hasAPIChanges = true
+	}
+	if !data.SnapshotTemplateID.Equal(state.SnapshotTemplateID) {
+		snapshotTemplateID := data.SnapshotTemplateID.ValueString()
+		updateReq.SnapshotTemplateID = &snapshotTemplateID
+		hasAPIChanges = true
+	}
+	if !data.HydrationTemplateID.Equal(state.HydrationTemplateID) {
+		hydrationTemplateID := data.HydrationTemplateID.ValueString()
+		updateReq.HydrationTemplateID = &hydrationTemplateID
+		hasAPIChanges = true
+	}
+	if !data.WatchedPermissions.Equal(state.WatchedPermissions) {
+		updateReq.WatchedPermissions = &watched
+		hasAPIChanges = true
+	}
+	if !data.Replicas.Equal(state.Replicas) {
+		updateReq.Replicas = optionalInt64(data.Replicas)
+		hasAPIChanges = true
+	}
+	if !data.AcceleratedQueries.Equal(state.AcceleratedQueries) {
+		updateReq.AcceleratedQueries = optionalBool(data.AcceleratedQueries)
+		hasAPIChanges = true
+	}
+
+	if !hasAPIChanges {
+		// Only non-API attributes changed (e.g. the timeouts block); the API
+		// rejects an empty update, and there is nothing to wait for.
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
+	}
+
+	id := state.ID.ValueString()
+	if err := r.client.UpdateMaterializeDeployment(updateCtx, id, updateReq); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update materialize deployment, got error: %s", err))
+		return
+	}
+
+	// The wait's final poll returns the deployment it observed, so no extra
+	// read is needed afterwards.
+	deployment, err := waitForMaterializeDeploymentReady(updateCtx, r.client, id)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Materialize Deployment Not Ready",
+			fmt.Sprintf("Deployment %s was updated but did not return to a ready state: %s. Increase the update timeout if the rollout needs more time.", id, err),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(applyMaterializeDeploymentToModel(ctx, deployment, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	applyPlannedOverrides(&data, plannedReplicas, plannedAcceleratedQueries)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *materializeDeploymentResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data materializeDeploymentResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// The API answers 202 Accepted; the client polls until the deployment is
+	// gone, bounded by the client-level DeleteTimeout.
+	if err := r.client.DeleteMaterializeDeployment(data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Error deleting materialize deployment", fmt.Sprintf("Unable to delete materialize deployment: %v", err))
+		return
+	}
+}
+
+// ImportState imports by the mc-... deployment ID alone; unlike other
+// resources, GET needs no permission system ID.
+func (r *materializeDeploymentResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -127,6 +127,7 @@ func (p *CloudProvider) Resources(_ context.Context) []func() resource.Resource 
 		NewPolicyResource,
 		NewServiceAccountResource,
 		NewTokenResource,
+		NewMaterializeDeploymentResource,
 	}
 	return resources
 }

--- a/internal/provider/resource_materialize_deployment_test.go
+++ b/internal/provider/resource_materialize_deployment_test.go
@@ -1,0 +1,103 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"terraform-provider-authzed/internal/test/helpers"
+)
+
+// testAccMaterializePreCheck skips Materialize acceptance tests unless the
+// Materialize-specific environment is configured, on top of the standard
+// acceptance env validation.
+func testAccMaterializePreCheck(t *testing.T) {
+	testAccPreCheck(t)
+	if helpers.GetTestDeploymentID() == "" {
+		t.Skip("AUTHZED_DEPLOYMENT_ID not set; skipping materialize deployment acceptance tests")
+	}
+	if len(helpers.GetTestMaterializeWatchedPermissions()) == 0 {
+		t.Skip("AUTHZED_MATERIALIZE_WATCHED_PERMISSIONS not set; skipping materialize deployment acceptance tests")
+	}
+}
+
+func testAccCheckMaterializeDeploymentDestroy(s *terraform.State) error {
+	testClient := helpers.CreateTestClient()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "authzed_materialize_deployment" {
+			continue
+		}
+		_, err := testClient.GetMaterializeDeployment(context.Background(), rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("materialize deployment %s still exists", rs.Primary.ID)
+		}
+		// A deleted deployment reads as 404 — or 403 on API versions where
+		// deletion removes the authorization relationships.
+		if !materializeDeploymentGone(err) {
+			return fmt.Errorf("unexpected error checking materialize deployment %s: %w", rs.Primary.ID, err)
+		}
+	}
+	return nil
+}
+
+func TestAccAuthzedMaterializeDeployment_basic(t *testing.T) {
+	name := helpers.GenerateTestID("tf-test-mat")
+	watched := helpers.GetTestMaterializeWatchedPermissions()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccMaterializePreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMaterializeDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: helpers.BuildMaterializeDeploymentConfigWithOptions(name, watched, 1, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("authzed_materialize_deployment.test", "id"),
+					resource.TestCheckResourceAttr("authzed_materialize_deployment.test", "name", name),
+					resource.TestCheckResourceAttr("authzed_materialize_deployment.test", "permission_system_id", helpers.GetTestPermissionSystemID()),
+					resource.TestCheckResourceAttr("authzed_materialize_deployment.test", "deployment_id", helpers.GetTestDeploymentID()),
+					resource.TestCheckResourceAttr("authzed_materialize_deployment.test", "watched_permissions.#", fmt.Sprintf("%d", len(watched))),
+					resource.TestCheckResourceAttr("authzed_materialize_deployment.test", "replicas", "1"),
+					resource.TestCheckResourceAttr("authzed_materialize_deployment.test", "accelerated_queries", "false"),
+				),
+			},
+			{
+				ResourceName:            "authzed_materialize_deployment.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeouts"},
+			},
+		},
+	})
+}
+
+func TestAccAuthzedMaterializeDeployment_update(t *testing.T) {
+	watched := helpers.GetTestMaterializeWatchedPermissions()
+	if len(watched) < 2 {
+		t.Skip("need at least 2 entries in AUTHZED_MATERIALIZE_WATCHED_PERMISSIONS for the update test")
+	}
+	name := helpers.GenerateTestID("tf-test-mat-upd")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccMaterializePreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMaterializeDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: helpers.BuildMaterializeDeploymentConfig(name, watched[:1]),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("authzed_materialize_deployment.test", "watched_permissions.#", "1"),
+				),
+			},
+			{
+				Config: helpers.BuildMaterializeDeploymentConfig(name, watched),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("authzed_materialize_deployment.test", "watched_permissions.#", fmt.Sprintf("%d", len(watched))),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/wait.go
+++ b/internal/provider/wait.go
@@ -2,11 +2,17 @@ package provider
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math/rand"
+	"net/http"
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
+
 	"terraform-provider-authzed/internal/client"
+	"terraform-provider-authzed/internal/models"
 )
 
 // waitForExists polls check(ctx) until it returns true, or the context is done.
@@ -91,4 +97,111 @@ func waitForRoleExists(ctx context.Context, client *client.CloudClient, psID, ro
 		}
 		return true, nil // Found!
 	})
+}
+
+// classifyMaterializeDeploymentError inspects err for an *client.APIError.
+func classifyMaterializeDeploymentError(err error) (isNotFound, isPermanent bool) {
+	var apiErr *client.APIError
+	if !errors.As(err, &apiErr) {
+		return false, false
+	}
+	if apiErr.StatusCode == http.StatusNotFound {
+		return true, false
+	}
+	return false, apiErr.StatusCode >= 400 && apiErr.StatusCode < 500
+}
+
+// materializeDeploymentGone reports whether err means the deployment no
+// longer exists: 404, or 403 on API versions where deletion removes the
+// deployment's authorization relationships and reads of a deleted deployment
+// are rejected as forbidden — matching the delete polling's gone semantics.
+func materializeDeploymentGone(err error) bool {
+	var apiErr *client.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.StatusCode == http.StatusNotFound || apiErr.StatusCode == http.StatusForbidden
+}
+
+// materializeDeploymentReady reports whether a deployment has been
+// provisioned and started doing useful work. Snapshotting and hydration are
+// data-dependent and can take hours, so waiting for the overall Running
+// phase (fully hydrated and serving) is unrealistic; instead the deployment
+// counts as ready once its snapshot job is underway (Running), already done
+// (Complete), or intentionally off (Disabled) — or once the deployment
+// somehow reached Running outright.
+func materializeDeploymentReady(deployment *models.MaterializeDeployment) bool {
+	if deployment.Status == nil {
+		return false
+	}
+	if deployment.Status.Phase == models.MaterializePhaseRunning {
+		return true
+	}
+	if deployment.Status.Snapshot == nil {
+		return false
+	}
+	switch deployment.Status.Snapshot.Phase {
+	case models.MaterializeJobPhaseRunning, models.MaterializeJobPhaseComplete, models.MaterializeJobPhaseDisabled:
+		return true
+	}
+	return false
+}
+
+// waitForMaterializeDeploymentReady waits for a materialize deployment to be
+// provisioned and snapshotting (see materializeDeploymentReady) — NOT fully
+// hydrated, which can take hours — and returns the deployment observed by
+// its final poll, saving callers a follow-up read. Callers control the
+// overall wait via ctx. A 404 means the deployment is not yet visible;
+// Degraded/Unknown phases can be transient during provisioning, so both keep
+// polling until ctx expires. Unlike waitForExists, this fails fast on any
+// other 4xx response (e.g. an invalid or expired token) instead of burning
+// the full wait budget on an error that will never resolve on its own.
+func waitForMaterializeDeploymentReady(ctx context.Context, cloudClient *client.CloudClient, id string) (*models.MaterializeDeployment, error) {
+	var ready *models.MaterializeDeployment
+	// lastState remembers what the most recent poll observed: on ctx expiry
+	// backoff.Retry returns a bare context error, and without this a stuck
+	// deployment times out with no hint of why (e.g. a Degraded phase).
+	var lastState error
+	operation := func() error {
+		deployment, err := cloudClient.GetMaterializeDeployment(ctx, id)
+		if err != nil {
+			isNotFound, isPermanent := classifyMaterializeDeploymentError(err)
+			switch {
+			case isNotFound:
+				// Not visible yet, keep waiting.
+				lastState = fmt.Errorf("not visible yet: %w", err)
+			case isPermanent:
+				// Permanent client error (e.g. a bad token); the client
+				// already retried 429s, so this won't resolve itself and
+				// there is no point burning the rest of the wait budget.
+				return backoff.Permanent(err)
+			default:
+				// Network error or a 5xx that survived the client's own retries.
+				lastState = err
+			}
+			return lastState
+		}
+		if materializeDeploymentReady(deployment) {
+			ready = deployment
+			return nil
+		}
+		phase := ""
+		snapshotPhase := ""
+		if deployment.Status != nil {
+			phase = deployment.Status.Phase
+			if deployment.Status.Snapshot != nil {
+				snapshotPhase = deployment.Status.Snapshot.Phase
+			}
+		}
+		lastState = fmt.Errorf("not ready yet (phase %q, snapshot phase %q)", phase, snapshotPhase)
+		return lastState
+	}
+
+	if err := backoff.Retry(operation, backoff.WithContext(client.NewPollBackOff(), ctx)); err != nil {
+		if lastState != nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
+			err = fmt.Errorf("%w (last state: %w)", err, lastState)
+		}
+		return nil, fmt.Errorf("waiting for materialize deployment %s to start snapshotting: %w", id, err)
+	}
+	return ready, nil
 }

--- a/internal/provider/wait_materialize_test.go
+++ b/internal/provider/wait_materialize_test.go
@@ -1,0 +1,147 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"terraform-provider-authzed/internal/client"
+	"terraform-provider-authzed/internal/models"
+)
+
+func TestWaitForMaterializeDeploymentReadySnapshotRunning(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		// First poll: not yet visible. Second: provisioning, snapshot pending.
+		// Third+: still provisioning overall, but the snapshot job is running —
+		// that is the readiness signal (full hydration can take hours).
+		if n == 1 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		snapshotPhase := "Pending"
+		if n >= 3 {
+			snapshotPhase = "Running"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"deployment": {"id": "mc-test", "name": "t", "permissionsSystemID": "ps-x", "deploymentID": "dp-x", "watchedPermissions": [], "status": {"phase": "Provisioning", "snapshot": {"phase": %q}}}}`, snapshotPhase)
+	}))
+	defer server.Close()
+
+	c := client.NewCloudClient(&client.CloudClientConfig{Host: server.URL, Token: "test-token"})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	deployment, err := waitForMaterializeDeploymentReady(ctx, c, "mc-test")
+	if err != nil {
+		t.Fatalf("waitForMaterializeDeploymentReady failed: %v", err)
+	}
+	if deployment == nil || deployment.ID != "mc-test" {
+		t.Fatalf("expected the observed deployment to be returned, got %+v", deployment)
+	}
+	if calls < 3 {
+		t.Fatalf("expected at least 3 polls (404, snapshot Pending, snapshot Running), got %d", calls)
+	}
+}
+
+func TestWaitForMaterializeDeploymentReadyRunningPhase(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"deployment": {"id": "mc-test", "name": "t", "permissionsSystemID": "ps-x", "deploymentID": "dp-x", "watchedPermissions": [], "status": {"phase": "Running"}}}`)
+	}))
+	defer server.Close()
+
+	c := client.NewCloudClient(&client.CloudClientConfig{Host: server.URL, Token: "test-token"})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	deployment, err := waitForMaterializeDeploymentReady(ctx, c, "mc-test")
+	if err != nil {
+		t.Fatalf("waitForMaterializeDeploymentReady failed on Running phase: %v", err)
+	}
+	if deployment == nil || deployment.ID != "mc-test" {
+		t.Fatalf("expected the observed deployment to be returned, got %+v", deployment)
+	}
+}
+
+func TestWaitForMaterializeDeploymentReadyTimesOut(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"deployment": {"id": "mc-test", "name": "t", "permissionsSystemID": "ps-x", "deploymentID": "dp-x", "watchedPermissions": [], "status": {"phase": "Provisioning", "snapshot": {"phase": "Pending"}}}}`)
+	}))
+	defer server.Close()
+
+	c := client.NewCloudClient(&client.CloudClientConfig{Host: server.URL, Token: "test-token"})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := waitForMaterializeDeploymentReady(ctx, c, "mc-test")
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	// The timeout must say what the last poll observed — a bare "context
+	// deadline exceeded" tells the operator nothing about why it is stuck.
+	if !strings.Contains(err.Error(), `phase "Provisioning"`) || !strings.Contains(err.Error(), `snapshot phase "Pending"`) {
+		t.Fatalf("expected timeout error to include the last observed state, got: %v", err)
+	}
+}
+
+func TestWaitForMaterializeDeploymentReadyFailsFastOn403(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = fmt.Fprint(w, `{"message": "forbidden"}`)
+	}))
+	defer server.Close()
+
+	c := client.NewCloudClient(&client.CloudClientConfig{Host: server.URL, Token: "test-token"})
+	// Generous ctx timeout: the point of this test is that we return well
+	// before it expires, proving the 403 short-circuits the wait instead of
+	// being retried until the context deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := waitForMaterializeDeploymentReady(ctx, c, "mc-test")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error for a permanent 403, got nil")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Fatalf("expected error to mention 403, got: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("expected fail-fast return well under the 10s ctx deadline, took %v", elapsed)
+	}
+}
+
+func TestMaterializeDeploymentReady(t *testing.T) {
+	cases := []struct {
+		name   string
+		status *models.MaterializeDeploymentStatus
+		want   bool
+	}{
+		{"nil status", nil, false},
+		{"provisioning, no snapshot info", &models.MaterializeDeploymentStatus{Phase: "Provisioning"}, false},
+		{"snapshot pending", &models.MaterializeDeploymentStatus{Phase: "Provisioning", Snapshot: &models.MaterializeDeploymentSnapshotInfo{Phase: "Pending"}}, false},
+		{"snapshot failed", &models.MaterializeDeploymentStatus{Phase: "Provisioning", Snapshot: &models.MaterializeDeploymentSnapshotInfo{Phase: "Failed"}}, false},
+		{"snapshot running", &models.MaterializeDeploymentStatus{Phase: "Provisioning", Snapshot: &models.MaterializeDeploymentSnapshotInfo{Phase: "Running"}}, true},
+		{"snapshot complete", &models.MaterializeDeploymentStatus{Phase: "Provisioning", Snapshot: &models.MaterializeDeploymentSnapshotInfo{Phase: "Complete"}}, true},
+		{"snapshot disabled", &models.MaterializeDeploymentStatus{Phase: "Provisioning", Snapshot: &models.MaterializeDeploymentSnapshotInfo{Phase: "Disabled"}}, true},
+		{"running phase without snapshot info", &models.MaterializeDeploymentStatus{Phase: "Running"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := materializeDeploymentReady(&models.MaterializeDeployment{Status: tc.status})
+			if got != tc.want {
+				t.Fatalf("materializeDeploymentReady = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/test/helpers/materialize_helpers.go
+++ b/internal/test/helpers/materialize_helpers.go
@@ -1,0 +1,109 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// GetTestDeploymentID returns the permission system deployment (dp-...) that
+// Materialize acceptance tests target. When unset, the Materialize
+// acceptance tests skip.
+func GetTestDeploymentID() string {
+	return os.Getenv("AUTHZED_DEPLOYMENT_ID")
+}
+
+// envOrDefault returns the env var's value, or fallback when unset/empty.
+func envOrDefault(name, fallback string) string {
+	if v := os.Getenv(name); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// The template fallbacks below (mtsc-default/mtssc-default/mthc-default)
+// only exist in AuthZed's local development stacks, so they are useful to
+// maintainers testing locally without extra configuration. Runs against any
+// real environment must set the AUTHZED_MATERIALIZE_*_TEMPLATE_ID variables
+// to templates that exist there (e.g. mtsc-1-vcpu).
+
+// GetTestMaterializeServerTemplateID returns the online hydration server template ID
+func GetTestMaterializeServerTemplateID() string {
+	return envOrDefault("AUTHZED_MATERIALIZE_SERVER_TEMPLATE_ID", "mtsc-default")
+}
+
+// GetTestMaterializeSnapshotTemplateID returns the snapshot template ID
+func GetTestMaterializeSnapshotTemplateID() string {
+	return envOrDefault("AUTHZED_MATERIALIZE_SNAPSHOT_TEMPLATE_ID", "mtssc-default")
+}
+
+// GetTestMaterializeHydrationTemplateID returns the offline hydration template ID
+func GetTestMaterializeHydrationTemplateID() string {
+	return envOrDefault("AUTHZED_MATERIALIZE_HYDRATION_TEMPLATE_ID", "mthc-default")
+}
+
+// GetTestMaterializeWatchedPermissions returns the comma-separated watched
+// permissions (resource_type#relation@subject_type) valid for the test
+// permission system's schema. Empty means Materialize tests should skip.
+func GetTestMaterializeWatchedPermissions() []string {
+	raw := os.Getenv("AUTHZED_MATERIALIZE_WATCHED_PERMISSIONS")
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	watched := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			watched = append(watched, trimmed)
+		}
+	}
+	return watched
+}
+
+// BuildMaterializeDeploymentConfig builds HCL for a materialize deployment
+// with the given name and watched permissions
+func BuildMaterializeDeploymentConfig(name string, watched []string) string {
+	return buildMaterializeDeploymentConfig(name, watched, "")
+}
+
+// BuildMaterializeDeploymentConfigWithOptions builds HCL for a materialize
+// deployment that also pins the optional replicas and accelerated_queries
+// attributes, exercising their round-trip through deployment status.
+func BuildMaterializeDeploymentConfigWithOptions(name string, watched []string, replicas int64, acceleratedQueries bool) string {
+	extraAttrs := fmt.Sprintf("  replicas              = %d\n  accelerated_queries   = %t\n", replicas, acceleratedQueries)
+	return buildMaterializeDeploymentConfig(name, watched, extraAttrs)
+}
+
+// buildMaterializeDeploymentConfig renders the shared resource block;
+// extraAttrs is appended verbatim inside it (one full attribute line each,
+// newline-terminated).
+func buildMaterializeDeploymentConfig(name string, watched []string, extraAttrs string) string {
+	quoted := make([]string, 0, len(watched))
+	for _, w := range watched {
+		quoted = append(quoted, fmt.Sprintf("%q", w))
+	}
+	return fmt.Sprintf(
+		`
+%s
+
+resource "authzed_materialize_deployment" "test" {
+  name                  = %q
+  permission_system_id  = %q
+  deployment_id         = %q
+  server_template_id    = %q
+  snapshot_template_id  = %q
+  hydration_template_id = %q
+  watched_permissions   = [%s]
+%s}
+`,
+		BuildProviderConfig(),
+		name,
+		GetTestPermissionSystemID(),
+		GetTestDeploymentID(),
+		GetTestMaterializeServerTemplateID(),
+		GetTestMaterializeSnapshotTemplateID(),
+		GetTestMaterializeHydrationTemplateID(),
+		strings.Join(quoted, ", "),
+		extraAttrs,
+	)
+}


### PR DESCRIPTION
## What

A new resource, `authzed_materialize_deployment`, for managing AuthZed Materialize deployments as code:

- **Full lifecycle**: create, read, update, delete, and import (`terraform import ... mc-...`).
- **Configuration**: watched permissions, server/snapshot/hydration templates, online hydration replica count (including `0` to pause a deployment without deleting it), and accelerated queries.
- **In-place updates** for templates, watched permissions, replicas, and accelerated queries; changing the name, permission system, or deployment forces replacement (the API does not support changing them).
- **Drift detection**: replicas and accelerated queries are read back from deployment status, and deployments deleted outside Terraform are detected and planned for recreation.
- Documentation including the available template ID matrix, an example configuration, and environment-gated acceptance tests.

## Why

Materialize deployments could previously only be managed through the dashboard or by calling the API directly. Teams managing their AuthZed permission systems with this provider had to leave Terraform to provision or reconfigure Materialize; this closes that gap and makes deployments reviewable, repeatable infrastructure.

## Design choices

- **Readiness semantics**: `create`/`update` return once the deployment is provisioned and its snapshot job has started — not once it is fully hydrated and serving, which is data-dependent and can take hours. Timeouts are configurable (default 30m).
- **API version**: the Materialize endpoints exist only under the `internal` API version, which carries no compatibility guarantees; the provider sends the required header automatically for this resource (regardless of the configured `api_version`) and the docs carry a prominent warning. Promotion to the public API is planned to align with the Materialize GA release (a one-line change in the provider).
- **Asynchronous delete**: the API accepts deletion with 202 and deprovisions in the background; the provider polls until the deployment is gone, treating 403 and 404 as "gone" since deleting a deployment also removes the caller's access to it (API versions differ in which of the two they return).
- **Lean client**: the Materialize API has no ETag/concurrency semantics, so the resource uses plain request/response client methods with 429/5xx retry instead of the provider's ETag machinery.
- **Apply consistency**: deployment status is composed asynchronously server-side, so after apply the provider prefers plan-specified values for the optional computed attributes over a possibly-stale status read; refresh detects real drift later.

## Testing

- Offline unit tests (httptest) for the client, readiness polling, and state mapping; acceptance tests (`TF_ACC`) gated on Materialize-specific env vars that skip cleanly when absent.
- Manually validated against a live environment: create, destroy, import with a clean follow-up plan, out-of-band deletion converging via recreation, in-place updates through both read-back paths, and forced replacement on rename.
